### PR TITLE
Fix FastAPI encoder import typo

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Request, HTTPException, UploadFile, File, Form, Body
 from fastapi.responses import HTMLResponse, StreamingResponse
-from fastapi.encploders import jsonable_encoder
+from fastapi.encoders import jsonable_encoder
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel


### PR DESCRIPTION
## Summary
- fix typo in main API module to import `jsonable_encoder` from `fastapi.encoders`

## Testing
- `cd backend && bash run_tests.sh` *(fails: assert 400 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_6894b66ccc84832d98347ead305b7042