### PR TITLE
Serve index template on root endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -899,7 +899,7 @@ async def history_data() -> list[dict]:
 # Rotas de interface web
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
-    return templates.TemplateResponse("nir_interface.html", {"request": request})
+    return templates.TemplateResponse("index.html", {"request": request})
 
 
 @app.get("/dashboard", response_class=HTMLResponse)


### PR DESCRIPTION
## Summary
- Serve `templates/index.html` from `/` so static images are displayed

## Testing
- `bash run_tests.sh` *(fails: 5 tests)*
- `uvicorn main:app --host 127.0.0.1 --port 8000 &`
- `curl http://127.0.0.1:8000/ | head`
- `curl -I http://127.0.0.1:8000/static/images/Logo.jpg`


------
https://chatgpt.com/codex/tasks/task_e_6894e860cee4832daddf22febe0a0da1