### PR TITLE
fix: ajustar rotas e servimento de imagens no backend e frontend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -898,8 +898,9 @@ async def history_data() -> list[dict]:
 
 # Rotas de interface web
 @app.get("/", response_class=HTMLResponse)
-async def index(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+async def nir_interface(request: Request):
+    """Renderiza a interface principal NIR."""
+    return templates.TemplateResponse("nir_interface.html", {"request": request})
 
 
 @app.get("/dashboard", response_class=HTMLResponse)
@@ -912,6 +913,3 @@ async def history_page(request: Request):
     return templates.TemplateResponse("history.html", {"request": request})
 
 
-@app.get("/nir", response_class=HTMLResponse)
-async def nir_interface(request: Request):
-    return templates.TemplateResponse("nir_interface.html", {"request": request})

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/jpeg" href="/static/images/Logo.jpg" />
+    <link rel="icon" type="image/jpeg" href="/images/Logo.jpg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NIR CONNECT</title>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Inter:wght@400;600&display=swap" rel="stylesheet" />

--- a/frontend/src/components/Analise.jsx
+++ b/frontend/src/components/Analise.jsx
@@ -1,3 +1,5 @@
+import serviceNir from '/images/service_nir.png';
+
 export default function Analise() {
   return (
     <section
@@ -6,7 +8,7 @@ export default function Analise() {
     >
       <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
         <img
-          src="/static/images/service_nir.png"
+          src={serviceNir}
           alt="Serviço de Análise NIR"
           className="rounded-lg shadow-md reveal-from-left"
           data-delay="0.2"

--- a/frontend/src/components/Consultoria.jsx
+++ b/frontend/src/components/Consultoria.jsx
@@ -1,3 +1,5 @@
+import consultoria from '/images/consultoria_personalizada.png';
+
 export default function Consultoria() {
   return (
     <section
@@ -6,7 +8,7 @@ export default function Consultoria() {
     >
       <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
         <img
-          src="/static/images/consultoria_personalizada.png"
+          src={consultoria}
           alt="Consultoria Personalizada NIR"
           className="rounded-lg shadow-md reveal-from-left"
           data-delay="0.2"

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import logo from '/images/Logo.jpg';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
@@ -7,7 +8,7 @@ export default function Header() {
       <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
         <a href="/" className="flex items-center space-x-3">
           <img
-            src="/static/images/Logo.jpg"
+            src={logo}
             alt="NIR CONNECT"
             className="h-14 md:h-16"
           />

--- a/frontend/src/components/Servicos.jsx
+++ b/frontend/src/components/Servicos.jsx
@@ -1,3 +1,7 @@
+import serviceNir from '/images/service_nir.png';
+import consultoria from '/images/consultoria_personalizada.png';
+import treinamento from '/images/treinamentos_especializados.png';
+
 export default function Servicos() {
   return (
     <section
@@ -10,7 +14,7 @@ export default function Servicos() {
           <li className="bg-white p-8 rounded-lg shadow-lg hover:shadow-2xl transition-transform transition-shadow">
             <a href="#analise" className="block space-y-4">
               <img
-                src="/static/images/service_nir.png"
+                src={serviceNir}
                 alt="Análise & Processamento NIR"
                 className="w-full rounded"
               />
@@ -23,7 +27,7 @@ export default function Servicos() {
           <li className="bg-white p-8 rounded-lg shadow-lg hover:shadow-2xl transition-transform transition-shadow">
             <a href="#consultoria" className="block space-y-4">
               <img
-                src="/static/images/consultoria_personalizada.png"
+                src={consultoria}
                 alt="Consultoria Personalizada NIR"
                 className="w-full rounded"
               />
@@ -36,7 +40,7 @@ export default function Servicos() {
           <li className="bg-white p-8 rounded-lg shadow-lg hover:shadow-2xl transition-transform transition-shadow">
             <a href="#treinamento" className="block space-y-4">
               <img
-                src="/static/images/treinamentos_especializados.png"
+                src={treinamento}
                 alt="Treinamentos Especializados em NIR"
                 className="w-full rounded"
               />

--- a/frontend/src/components/Sobre.jsx
+++ b/frontend/src/components/Sobre.jsx
@@ -1,3 +1,5 @@
+import sobre from '/images/sobre.png';
+
 export default function Sobre() {
   return (
     <section
@@ -15,7 +17,7 @@ export default function Sobre() {
       </div>
       <div className="md:w-7/12 mt-12 md:mt-0 flex justify-end reveal-from-left" data-delay="0.4">
         <img
-          src="/static/images/sobre.png"
+          src={sobre}
           alt="Ilustração Sobre"
           className="w-full rounded-lg shadow-lg"
         />

--- a/frontend/src/components/Treinamento.jsx
+++ b/frontend/src/components/Treinamento.jsx
@@ -1,3 +1,5 @@
+import treinamento from '/images/treinamentos_especializados.png';
+
 export default function Treinamento() {
   return (
     <section
@@ -6,7 +8,7 @@ export default function Treinamento() {
     >
       <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
         <img
-          src="/static/images/treinamentos_especializados.png"
+          src={treinamento}
           alt="Treinamentos Especializados em NIR"
           className="rounded-lg shadow-md reveal-from-left"
           data-delay="0.2"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -20,7 +20,7 @@ section {
 
 /* HERO */
 .hero {
-  background: url('/static/images/hero_image.png') center/cover no-repeat fixed;
+  background: url('/images/hero_image.png') center/cover no-repeat fixed;
   position: relative;
   min-height: 100vh;
   padding-top: 4rem;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,6 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  publicDir: 'public',
+  base: '/',
 })


### PR DESCRIPTION
## Resumo
- Redireciona a rota raiz do backend para `nir_interface.html` e remove referência antiga ao `index.html`.
- Ajusta caminhos e importações de imagens no frontend, configurando Vite para servir arquivos em `public`.

## Testes
- `uvicorn main:app --reload`
- `npm run dev`
- `pytest` *(falhou: assert 400 == 200 em testes da API)*

------
https://chatgpt.com/codex/tasks/task_e_6894f06acdbc832dba5e77b9684d6eb0