### PR TITLE
feat: add client-side routing and API fetch

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException, UploadFile, File, Form, Body
 from fastapi.responses import StreamingResponse, FileResponse
 from fastapi.encoders import jsonable_encoder
 from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import os
 import json
@@ -24,6 +25,13 @@ from core.interpreter import interpretar_vips, gerar_resumo_interpretativo
 from core.pls import is_categorical
 
 app = FastAPI(title="NIR API v4.6")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
@@ -892,6 +900,10 @@ async def history_data() -> list[dict]:
         with open(HISTORY_FILE, 'r') as fh:
             return json.load(fh)
     return []
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
 
 @app.get("/", summary="Health check")
 async def root():

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -1603,6 +1604,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2475,6 +2485,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.0.tgz",
+      "integrity": "sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.0.tgz",
+      "integrity": "sha512-ntInsnDVnVRdtSu6ODmTQ41cbluak/ENeTif7GBce0L6eztFg6/e1hXAysFQI8X25C8ipKmT9cClbJwxx3Kaqw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2540,6 +2588,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,71 +1,12 @@
-import { useEffect } from 'react';
-import Header from './components/Header';
-import Hero from './components/Hero';
-import Sobre from './components/Sobre';
-import Servicos from './components/Servicos';
-import Analise from './components/Analise';
-import Consultoria from './components/Consultoria';
-import Treinamento from './components/Treinamento';
-import Contato from './components/Contato';
+import { Routes, Route } from 'react-router-dom';
+import Home from './Home.jsx';
+import NirPage from './NirPage.jsx';
 
 export default function App() {
-  useEffect(() => {
-    // Smooth scrolling
-    document.querySelectorAll('a[href^="#"]').forEach((a) => {
-      a.addEventListener('click', (e) => {
-        if (a.getAttribute('href').startsWith('#')) {
-          e.preventDefault();
-          const tgt = document.querySelector(a.getAttribute('href'));
-          if (tgt) {
-            const top = tgt.getBoundingClientRect().top + window.pageYOffset - 80;
-            window.scrollTo({ top, behavior: 'smooth' });
-          }
-        }
-      });
-    });
-
-    // Slide-in reveals
-    document.querySelectorAll('.reveal-from-left').forEach((el) => {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              el.style.animationDelay = el.dataset.delay + 's';
-              el.classList.add('animate-from-left');
-            } else {
-              el.classList.remove('animate-from-left');
-            }
-          });
-        },
-        { threshold: 0.2 }
-      );
-      observer.observe(el);
-    });
-
-    // Fade-in-up for detail sections
-    document.querySelectorAll('.detail-section').forEach((sec) => {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            entry.target.classList.toggle('visible', entry.isIntersecting);
-          });
-        },
-        { threshold: 0.2 }
-      );
-      observer.observe(sec);
-    });
-  }, []);
-
   return (
-    <>
-      <Header />
-      <Hero />
-      <Sobre />
-      <Servicos />
-      <Analise />
-      <Consultoria />
-      <Treinamento />
-      <Contato />
-    </>
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/nir" element={<NirPage />} />
+    </Routes>
   );
 }

--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+import Header from './components/Header';
+import Hero from './components/Hero';
+import Sobre from './components/Sobre';
+import Servicos from './components/Servicos';
+import Analise from './components/Analise';
+import Consultoria from './components/Consultoria';
+import Treinamento from './components/Treinamento';
+import Contato from './components/Contato';
+
+export default function Home() {
+  useEffect(() => {
+    // Smooth scrolling
+    document.querySelectorAll('a[href^="#"]').forEach((a) => {
+      a.addEventListener('click', (e) => {
+        if (a.getAttribute('href').startsWith('#')) {
+          e.preventDefault();
+          const tgt = document.querySelector(a.getAttribute('href'));
+          if (tgt) {
+            const top = tgt.getBoundingClientRect().top + window.pageYOffset - 80;
+            window.scrollTo({ top, behavior: 'smooth' });
+          }
+        }
+      });
+    });
+
+    // Slide-in reveals
+    document.querySelectorAll('.reveal-from-left').forEach((el) => {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              el.style.animationDelay = el.dataset.delay + 's';
+              el.classList.add('animate-from-left');
+            } else {
+              el.classList.remove('animate-from-left');
+            }
+          });
+        },
+        { threshold: 0.2 }
+      );
+      observer.observe(el);
+    });
+
+    // Fade-in-up for detail sections
+    document.querySelectorAll('.detail-section').forEach((sec) => {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            entry.target.classList.toggle('visible', entry.isIntersecting);
+          });
+        },
+        { threshold: 0.2 }
+      );
+      observer.observe(sec);
+    });
+  }, []);
+
+  return (
+    <>
+      <Header />
+      <Hero />
+      <Sobre />
+      <Servicos />
+      <Analise />
+      <Consultoria />
+      <Treinamento />
+      <Contato />
+    </>
+  );
+}

--- a/frontend/src/NirPage.jsx
+++ b/frontend/src/NirPage.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export default function NirPage() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/health')
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Erro: ${res.status}`);
+        }
+        return res.json();
+      })
+      .then((json) => setData(json))
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">NIR Page</h1>
+      {error && <p>{error}</p>}
+      {data && <pre>{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/frontend/src/components/Hero.jsx
+++ b/frontend/src/components/Hero.jsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 export default function Hero() {
   return (
     <section id="hero" className="hero snap-start relative flex items-center justify-center text-center px-6 min-h-screen overflow-hidden">
@@ -9,13 +11,13 @@ export default function Hero() {
         <p className="reveal-from-left text-3xl text-gray-200" data-delay="0.3">
           Descubra como processar dados NIR de forma simples e moderna.
         </p>
-        <button
-          onClick={() => (window.location.href = '/nir')}
+        <Link
+          to="/nir"
           className="reveal-from-left inline-block bg-emerald-700 hover:bg-emerald-800 text-white font-semibold py-4 px-8 rounded-md shadow-lg"
           data-delay="0.5"
         >
-          Acessar Plataforma
-        </button>
+          Acessar a Plataforma
+        </Link>
       </div>
     </section>
   );

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import './index.css';
+import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## Summary
- set up React Router with Home and NirPage components
- enable CORS and health route on backend for frontend API calls

## Testing
- `cd backend && uvicorn main:app --reload` (GET /health)
- `cd frontend && npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6894faa3897c832d91bb563f1e4d9b9e