### PR TITLE
Fix API service and router setup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, UploadFile, File, Form, Body, APIRouter
+from fastapi import FastAPI, HTTPException, UploadFile, File, Form, Body
 from fastapi.responses import StreamingResponse
 from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
@@ -34,12 +34,6 @@ import joblib
 OPTIMIZE_PROGRESS = {"current": 0, "total": 0}
 
 app = FastAPI(title="NIR API v4.6")
-model_router = APIRouter(tags=["Model"])
-
-
-app.include_router(model_router)
-
-app.include_router(model_router.router)
 
 
 app.add_middleware(


### PR DESCRIPTION
## Summary
- remove incorrect router registration from backend
- rewrite frontend API service using valid JavaScript and root endpoints

## Testing
- `npm run lint` *(fails: Empty block statement, no-empty, no-unused-vars)*
- `bash backend/run_tests.sh` *(fails: file or directory not found: tests/)*

------
https://chatgpt.com/codex/tasks/task_e_689cc498fcf8832d9e8d8570ce1df940