### PR TITLE
Handle non-numeric spectra and label encoding for PLS-DA

### DIFF
--- a/backend/core/io_utils.py
+++ b/backend/core/io_utils.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 
 def to_float_matrix(X_like: Any) -> np.ndarray:
-    """Converte X em float, coerçando texto->NaN e ±inf->NaN."""
+    """Converte X para float, coerçando texto->NaN e ±inf->NaN."""
     df = pd.DataFrame(X_like)
     df = df.apply(pd.to_numeric, errors="coerce")
     X = df.to_numpy(dtype=float)
@@ -13,14 +13,14 @@ def to_float_matrix(X_like: Any) -> np.ndarray:
 
 
 def encode_labels_if_needed(y_like: List[Any]) -> Tuple[np.ndarray, Dict[int, str], int]:
-    """Se y for texto/categórico, codifica (0..K-1) e retorna mapping e K.
-       Se já for numérico, retorna como float e mapping vazio."""
+    """Se y for categórico/texto, codifica (0..K-1) e retorna mapping e nº de classes."""
     s = pd.Series(y_like)
     if pd.api.types.is_numeric_dtype(s):
         y = pd.to_numeric(s, errors="coerce").to_numpy(dtype=float)
-        return y, {}, len(pd.unique(s.dropna()))
+        n = pd.unique(s.dropna()).size
+        return y, {}, int(n)
     from sklearn.preprocessing import LabelEncoder
     le = LabelEncoder()
     y_num = le.fit_transform(s.astype(str))
     mapping = {int(i): str(cls) for i, cls in enumerate(le.classes_)}
-    return y_num.astype(float), mapping, len(le.classes_)
+    return y_num.astype(float), mapping, int(len(le.classes_))

--- a/backend/main.py
+++ b/backend/main.py
@@ -554,7 +554,7 @@ async def process_file(
             raise HTTPException(status_code=400, detail=f"A coluna '{target}' não foi encontrada no arquivo.")
 
         # 2) prepara X/feature names uma vez só
-        X_df = df.drop(columns=[target])
+        X_df = df.drop(columns=[target], errors="ignore")
         features = X_df.columns.tolist()
         X = X_df.values
 
@@ -738,12 +738,12 @@ async def analisar_file(
 
         # X / features (+ faixas)
         # =========================
-        X_df = df.drop(columns=[target])
+        X_df = df.drop(columns=[target], errors="ignore")
         if spectral_ranges:
             cols = _parse_ranges(spectral_ranges, X_df.columns.tolist())
             X_df = X_df[cols]
         features = X_df.columns.tolist()
-        X = to_float_matrix(X_df)
+        X = to_float_matrix(X_df.values)
 
         methods = _parse_preprocess(preprocess)
         if methods:
@@ -762,7 +762,7 @@ async def analisar_file(
                 )
         else:
             y_arr = pd.to_numeric(pd.Series(y_raw), errors="coerce").to_numpy(dtype=float)
-            class_mapping = {}
+            class_mapping, n_classes = {}, 0
 
         X, y_arr, features = saneamento_global(X, y_arr, features)
 


### PR DESCRIPTION
## Summary
- Add utilities to coerce feature matrices to float and encode categorical labels
- Sanitize `/analisar` route to drop target column, convert spectra to float, and encode class labels when classification is enabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce3dc8b6c832d880877efa2b98161