### PR TITLE
feat: enable multiclass PLS-DA

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ curl -X POST http://localhost:8000/model/preprocess \
      -d '{"X": [[1,2],[3,4]]}'
 ```
 
+
+### Multiclass PLS-DA
+
+O backend agora suporta classificação PLS-DA multiclasse via estratégia One-Vs-Rest, retornando probabilidades por classe e métricas macro.

--- a/backend/core/metrics.py
+++ b/backend/core/metrics.py
@@ -5,6 +5,8 @@ from sklearn.metrics import (
     accuracy_score,
     confusion_matrix,
     f1_score,
+    precision_score,
+    recall_score,
     cohen_kappa_score,
     classification_report,
 )
@@ -22,8 +24,10 @@ def regression_metrics(y_true, y_pred):
 
 def classification_metrics(y_true, y_pred, labels=None):
     acc = accuracy_score(y_true, y_pred)
-    f1_macro = f1_score(y_true, y_pred, average="macro")
-    f1_micro = f1_score(y_true, y_pred, average="micro")
+    prec = precision_score(y_true, y_pred, average="macro", zero_division=0)
+    rec = recall_score(y_true, y_pred, average="macro", zero_division=0)
+    f1_macro = f1_score(y_true, y_pred, average="macro", zero_division=0)
+    f1_micro = f1_score(y_true, y_pred, average="micro", zero_division=0)
     kappa = cohen_kappa_score(y_true, y_pred)
     cm = confusion_matrix(y_true, y_pred, labels=labels)
     report = classification_report(
@@ -66,6 +70,9 @@ def classification_metrics(y_true, y_pred, labels=None):
         "Sensitivity_per_class": sens_by_class,
         "SensitivityDescription": desc,
         "ClassificationReport": report,
+        "MacroPrecision": float(prec),
+        "MacroRecall": float(rec),
+        "MacroF1": float(f1_macro),
     }
 
 def vip_scores(pls_model, X, Y):

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -273,8 +273,10 @@ def test_analisar_multiclass(tmp_path):
                 "decision_mode": "argmax",
             },
         )
-    assert resp.status_code == 400
-    assert "suporta apenas 2 classes" in resp.json()["detail"]
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["analysis_type"] == "PLS-DA"
+    assert len(data["metrics"]["ConfusionMatrix"]) == 3
 
 
 def test_analisar_with_custom_cv(tmp_path):

--- a/backend/tests/test_core.py
+++ b/backend/tests/test_core.py
@@ -48,7 +48,7 @@ def test_train_pls_classification():
     X, y = generate_classification_data()
     model, metrics, extra = train_pls(X, y, n_components=2, classification=True)
     assert model.classification
-    assert set(metrics.keys()) >= {"Accuracy", "F1_macro", "ConfusionMatrix", "Sensitivity", "Specificity", "Sensitivity_per_class"}
+    assert set(metrics.keys()) >= {"Accuracy", "F1_macro", "ConfusionMatrix", "Sensitivity", "Specificity", "Sensitivity_per_class", "MacroPrecision", "MacroRecall", "MacroF1"}
     assert metrics["Accuracy"] >= 0.8
     assert len(extra["vip"]) == X.shape[1]
 
@@ -56,7 +56,7 @@ def test_train_pls_classification():
 def test_train_plsda_binary_threshold():
     from core.bootstrap import train_plsda
     X, y = generate_classification_data()
-    model, metrics, extra = train_plsda(X, y, n_components=2, threshold=0.4)
+    model, metrics, extra = train_plsda(X, y, n_components=2)
     assert metrics["Accuracy"] >= 0.5
     assert extra["classes"] == ["0", "1"]
 
@@ -69,6 +69,7 @@ def test_train_pls_multiclass():
     assert len(metrics["ConfusionMatrix"]) == 3
     assert metrics["Accuracy"] >= 0.3
     assert list(model.classes_) == ["0", "1", "2"]
+    assert "MacroPrecision" in metrics and "MacroRecall" in metrics and "MacroF1" in metrics
 
 
 def test_bootstrap_metrics():


### PR DESCRIPTION
## Summary
- add One-vs-Rest PLS-DA implementation with probability output
- expose macro precision/recall/F1 metrics and sanitation utilities
- update API and validation to support multiclass classification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf3a6f3b8832da534972adc99036f