### PR TITLE
fix: send correct params to optimization

### DIFF
--- a/frontend/src/components/nir/Step3Preprocess.jsx
+++ b/frontend/src/components/nir/Step3Preprocess.jsx
@@ -170,9 +170,14 @@ export default function Step3Preprocess({ file, meta, step2, onBack, onAnalyzed 
       }
 
       const data = await postTrainForm(fd);
+      console.debug('[Step3] rangesStr =', rangesStr);
+      console.debug('[Step3] methods =', methods);
+      console.debug('[Step3] step2 =', step2);
+      console.debug('[Step3] data.range_used =', data?.range_used);
+
       const fullParams = {
-        ...step2,
-        spectral_ranges: rangesStr,
+        ...step2,               // <-- spread correto do objeto vindo do Step2
+        ranges: rangesStr,      // <-- nome que o Step4 e a otimização esperam
         preprocess_steps: methods,
         range_used: data.range_used,
       };

--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -63,6 +63,7 @@ export default function Step4Decision({ file, step2, result, onBack, onContinue 
     setPollId(id);
 
     try {
+      console.debug('[Step4] params recebidos =', result?.params);
       const payload = {
         target: step2.target,
         validation_method: step2.validation_method,


### PR DESCRIPTION
## Summary
- send spectral ranges using `ranges` key and spread Step2 params correctly
- add debug logs to help trace Step3→Step4 parameters

## Testing
- ⚠️ `npm test` (missing script)
- ⚠️ `npm run lint` (Unreachable code in src/services/api.js)
- ✅ `npx eslint src/components/nir/Step3Preprocess.jsx src/components/nir/Step4Decision.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689cfc2fede8832dae5d7ac002832e19