### PR TITLE
fix: send correct params to optimization

### DIFF
--- a/frontend/src/components/nir/Step3Preprocess.jsx
+++ b/frontend/src/components/nir/Step3Preprocess.jsx
@@ -170,9 +170,14 @@ export default function Step3Preprocess({ file, meta, step2, onBack, onAnalyzed 
       }
 
       const data = await postTrainForm(fd);
+      console.debug('[Step3] rangesStr =', rangesStr);
+      console.debug('[Step3] methods =', methods);
+      console.debug('[Step3] step2 =', step2);
+      console.debug('[Step3] data.range_used =', data?.range_used);
+
       const fullParams = {
-        ...step2,
-        spectral_ranges: rangesStr,
+        ...step2,               // <-- spread correto do objeto vindo do Step2
+        ranges: rangesStr,      // <-- nome que o Step4 e a otimização esperam
         preprocess_steps: methods,
         range_used: data.range_used,
       };

--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -63,6 +63,7 @@ export default function Step4Decision({ file, step2, result, onBack, onContinue 
     setPollId(id);
 
     try {
+      console.debug('[Step4] params recebidos =', result?.params);
       const payload = {
         target: step2.target,
         validation_method: step2.validation_method,
@@ -81,7 +82,7 @@ export default function Step4Decision({ file, step2, result, onBack, onContinue 
       setOptResults(data.results || []);
       setProgress(100);
     } catch (e) {
-      setError(typeof e === "string" ? e : "Falha na otimização.");
+      setError(typeof e === "string" ? e : (e?.message || "Falha na otimização."));
     } finally {
       setRunning(false);
       if (pollId) clearInterval(pollId);
@@ -294,12 +295,19 @@ export default function Step4Decision({ file, step2, result, onBack, onContinue 
         </>
       )}
 
-      {/* Tabela e gráfico */}
-      {optResults && optResults.length > 0 && (
-        <>
-          {renderTable(optResults)}
-          <div id="decisionChart" className="w-full h-80 mt-4" />
-        </>
+      {/* Resultados ou mensagem */}
+      {optResults && (
+        optResults.length > 0 ? (
+          <>
+            {renderTable(optResults)}
+            <div id="decisionChart" className="w-full h-80 mt-4" />
+          </>
+        ) : (
+          <div className="text-sm text-gray-700">
+            Nenhum resultado foi retornado pela otimização.
+            Tente reduzir o número de componentes ou trocar o método de validação (ex.: KFold).
+          </div>
+        )
       )}
 
       <div className="flex gap-2 pt-2">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -28,13 +28,23 @@ export async function postOptimize(file, params) {
   fd.append('file', file);
   fd.append('params', JSON.stringify(params));
   const res = await fetch(`${API_BASE}/optimize`, { method: 'POST', body: fd });
-  if (!res.ok) throw new Error(await res.text());
+  if (!res.ok) {
+    let msg;
+    try { const j = await res.json(); msg = j.detail || JSON.stringify(j); }
+    catch { msg = await res.text(); }
+    throw new Error(msg || 'Erro ao otimizar.');
+  }
   return res.json();
 }
 
 export async function getOptimizeStatus() {
   const res = await fetch(`${API_BASE}/optimize/status`);
-  if (!res.ok) throw new Error(await res.text());
+  if (!res.ok) {
+    let msg;
+    try { const j = await res.json(); msg = j.detail || JSON.stringify(j); }
+    catch { msg = await res.text(); }
+    throw new Error(msg || 'Erro ao consultar status.');
+  }
   return res.json();
 }
 
@@ -151,11 +161,6 @@ export async function postTrainForm(fd) {
     } catch (e) { last = e; }
   }
   throw last || new Error('Nenhuma rota de treino encontrada.');
-
-  const res = await fetch(`${API_BASE}/train`, { method: 'POST', body: fd });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
-
 }
 
 const api = {


### PR DESCRIPTION
## Summary
- send spectral ranges using `ranges` key and spread Step2 params correctly
- display optimization results or an informative message, and surface detailed backend errors
- improve error propagation in optimization API helpers

## Testing
- ⚠️ `npm test` (missing script: "test")
- ⚠️ `npm run lint` (7 warnings)
- ✅ `npm run build`
- ⚠️ `npx eslint src/components/nir/Step3Preprocess.jsx src/components/nir/Step4Decision.jsx src/services/api.js` (4 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689cfc2fede8832dae5d7ac002832e19