### PR TITLE
Support multiclass PLS-DA with logistic regression

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -140,6 +140,8 @@ def optimize_handler(X: np.ndarray, y: np.ndarray, params: dict, progress_callba
                                         "Accuracy": m["Accuracy"],
                                         "MacroF1": m["MacroF1"],
                                     },
+                                    "ConfusionMatrix": m.get("ConfusionMatrix"),
+                                    "labels": m.get("labels"),
                                     "validation": {"method": params.get("validation_method")},
                                     "wl_used": params.get("spectral_range") or [],
                                 }
@@ -154,6 +156,8 @@ def optimize_handler(X: np.ndarray, y: np.ndarray, params: dict, progress_callba
                                     "preprocess": prep,
                                     "n_components": nc,
                                     "val_metrics": {"Accuracy": float(m["Accuracy"])},
+                                    "ConfusionMatrix": m.get("ConfusionMatrix"),
+                                    "labels": m.get("labels"),
                                     "validation": {"method": params.get("validation_method")},
                                     "wl_used": params.get("spectral_range") or [],
                                 }
@@ -198,6 +202,8 @@ def optimize_handler(X: np.ndarray, y: np.ndarray, params: dict, progress_callba
                                     "Accuracy": m["Accuracy"],
                                     "MacroF1": m["MacroF1"],
                                 },
+                                "ConfusionMatrix": m.get("ConfusionMatrix"),
+                                "labels": m.get("labels"),
                                 "validation": {"method": params.get("validation_method")},
                                 "wl_used": params.get("spectral_range") or [],
                             }
@@ -210,6 +216,8 @@ def optimize_handler(X: np.ndarray, y: np.ndarray, params: dict, progress_callba
                                 "preprocess": preps_fb[0],
                                 "n_components": nc_fb,
                                 "val_metrics": {"Accuracy": float(m["Accuracy"])},
+                                "ConfusionMatrix": m.get("ConfusionMatrix"),
+                                "labels": m.get("labels"),
                                 "validation": {"method": params.get("validation_method")},
                                 "wl_used": params.get("spectral_range") or [],
                             }


### PR DESCRIPTION
## Summary
- add multi-class PLS-DA evaluation and final fitting utilities using PLS scores + logistic regression
- include confusion matrix and labels in optimization results for classification tasks
- refactor training helpers to use new logistic PLS-DA pipeline

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d43f0a354832d8e7f670417c09512