### PR TITLE
Support robust LOO validation and preprocessing

### DIFF
--- a/backend/core/autooptimize.py
+++ b/backend/core/autooptimize.py
@@ -3,12 +3,14 @@ from .bootstrap import train_plsr, train_plsda
 def auto_optimize(X, y, classification=False, max_components=10):
     results = []
     for nc in range(1, max_components + 1):
-        if classification:
-            _, metrics, _ = train_plsda(X, y, n_components=nc)
-        else:
-            _, metrics, _ = train_plsr(X, y, n_components=nc)
-        metrics["n_components"] = nc
-        results.append(metrics)
-    key_func = (lambda x: x.get("RMSECV", 1e6)) if not classification else (lambda x: -x.get("accuracy", 0))
-    results_sorted = sorted(results, key=key_func)
-    return results_sorted
+        try:
+            if classification:
+                _, metrics, _ = train_plsda(X, y, n_components=nc)
+            else:
+                _, metrics, _ = train_plsr(X, y, n_components=nc)
+            metrics["n_components"] = nc
+            results.append(metrics)
+        except Exception:
+            continue
+    key_func = (lambda x: x.get("RMSECV", 1e9)) if not classification else (lambda x: -x.get("Accuracy", 0))
+    return sorted(results, key=key_func)

--- a/backend/core/preprocessing.py
+++ b/backend/core/preprocessing.py
@@ -1,4 +1,5 @@
 import numpy as np
+from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from scipy.signal import savgol_filter
 
 
@@ -14,23 +15,21 @@ def snv(X: np.ndarray) -> np.ndarray:
 
 
 def msc(X: np.ndarray, reference: np.ndarray | None = None) -> np.ndarray:
-    """Multiplicative Scatter Correction with safe slope."""
     if reference is None:
         reference = np.mean(X, axis=0)
-    corrected = np.zeros_like(X)
+    corrected = np.zeros_like(X, dtype=float)
+    eps = 1e-12
     for i in range(X.shape[0]):
-        fit = np.polyfit(reference, X[i], 1, full=True)
-        slope = fit[0][0]
-        intercept = fit[0][1]
-        slope = slope if abs(slope) > EPS else 1.0
+        slope, intercept = np.polyfit(reference, X[i], 1)
+        if abs(slope) < eps:
+            slope = eps
         corrected[i] = (X[i] - intercept) / slope
     return corrected
 
 
 def savgol_derivative(X: np.ndarray, order: int = 1, window: int = 11, poly: int = 2) -> np.ndarray:
-    """Savitzky-Golay derivative ensuring valid window."""
-    if window <= poly:
-        window = poly + 2
+    if window < (poly + 2):
+        window = poly + 3
     if window % 2 == 0:
         window += 1
     return savgol_filter(X, window_length=window, polyorder=poly, deriv=order, axis=1)


### PR DESCRIPTION
## Summary
- Add adaptive cross-validation builder with Leave-One-Out and automatic split limiting
- Harden MSC and Savitzky-Golay preprocessing against zero slope and invalid windows
- Sanitize feature matrix and cap component count in PLS models and optimization grid
- Enable `/optimize` endpoint to forward validation method and skip failing auto-optimize components
- Handle NaN variance when filtering wavelengths during optimization

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4f1cf274832d937612c39a308f04