### PR TITLE
Support LOO validation in optimization endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1275,7 +1275,13 @@ async def optimize_endpoint(
         max_comp = max(1, min(max_comp, X.shape[1]))
 
         # --- validação
-        val_method = parsed.get("validation_method") or ("StratifiedKFold" if classification else "KFold")
+        raw_val_method = parsed.get("validation_method")
+        if raw_val_method == "LOO":
+            val_method = "LOO"
+        elif classification:
+            val_method = raw_val_method or "StratifiedKFold"
+        else:
+            val_method = raw_val_method or "KFold"
         if val_method == "Holdout":
             raise HTTPException(status_code=422, detail="Holdout não é suportado na otimização. Use KFold ou LOO.")
         val_params = {}


### PR DESCRIPTION
## Summary
- Allow using `LOO` as validation method for PLS-DA optimization
- Default to StratifiedKFold for classification and KFold for regression when not specified

## Testing
- `bash run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689ddffb8ed0832d8d0c02391cda4326