### PR TITLE
feat: expand evaluation metrics for regression and classification

### DIFF
--- a/backend/tests/test_core.py
+++ b/backend/tests/test_core.py
@@ -39,7 +39,7 @@ def test_train_pls_regression():
     X, y = generate_regression_data()
     model, metrics, extra = train_pls(X, y, n_components=3)
     assert not model.classification
-    assert set(metrics.keys()) == {"RMSE", "MAE", "R2"}
+    assert set(metrics.keys()) >= {"RMSE", "MAE", "R2", "MAPE", "ExplainedVariance"}
     assert metrics["R2"] > 0.8
     assert len(extra["vip"]) == X.shape[1]
 


### PR DESCRIPTION
## Summary
- add MAPE and explained variance to regression metrics
- include Cohen's kappa and confusion matrix in classification metrics with native Python types
- adjust tests for new metric outputs

## Testing
- `cd backend && bash run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689de6db0fd8832d898b94120962eaca