### PR TITLE
feat: add stratified k-fold option and LOO warnings

### DIFF
--- a/frontend/src/components/nir/Step2Parameters.jsx
+++ b/frontend/src/components/nir/Step2Parameters.jsx
@@ -271,9 +271,15 @@ export default function Step2Parameters({ meta, onBack, onNext }) {
             onChange={(e) => setValidationMethod(e.target.value)}
           >
             <option value="KFold">K-Fold</option>
+            {classification && <option value="StratifiedKFold">Stratified K-Fold</option>}
             <option value="LOO">Leave-One-Out (LOO)</option>
             <option value="Holdout">Train/Test Split</option>
           </select>
+          {validationMethod === "LOO" && (
+            <p className="mt-1 text-xs text-amber-700">
+              LOO executa 1 treino por amostra (pode ser lento em bases grandes).
+            </p>
+          )}
         </div>
 
         {/* params de validação condicionais */}

--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -460,6 +460,11 @@ export default function Step4Decision({ file, step2, result, onBack, onContinue 
 
       {(running || progress > 0) && (
         <>
+          {step2?.validation_method === "LOO" && (
+            <div className="text-xs text-amber-700 mb-2">
+              Executando Leave-One-Out — cada combinação roda N vezes (N = número de amostras). Pode levar mais tempo.
+            </div>
+          )}
           <div className="w-full bg-gray-200 rounded">
             <div className="h-2 bg-green-500 transition-all" style={{ width: `${progress}%` }} />
           </div>


### PR DESCRIPTION
## Summary
- add Stratified K-Fold option to validation selector when classification is enabled
- show UX notice when Leave-One-Out is chosen in parameters and during optimization

## Testing
- `npm test` (missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dee13bd8c832d962e25771d450543