### PR TITLE
Handle NaNs in PLS metrics and progress

### DIFF
--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -178,9 +178,11 @@ export default function Step4Decision({ file, step2, result, onBack, onContinue 
     pollRef.current = setInterval(async () => {
       try {
         const s = await getOptimizeStatus();
-        const pct = s?.total ? Math.round((s.current / s.total) * 100) : 0;
+        const current = Number(s?.current ?? 0);
+        const total = Number(s?.total ?? 0);
+        const pct = total > 0 ? Math.round((current / total) * 100) : 0;
         setProgress(Math.max(0, Math.min(100, pct)));
-        if (s?.total && s.current >= s.total) {
+        if (total > 0 && current >= total) {
           if (pollRef.current) clearInterval(pollRef.current);
         }
       } catch { /* ignora polling error */ }


### PR DESCRIPTION
## Summary
- sanitize classification metrics to avoid NaNs
- make grid search scoring resilient to missing metrics
- harden frontend progress polling against null values

## Testing
- `bash run_tests.sh`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689f886a4854832daefbd92b6e6af5e5