### PR TITLE
feat: enforce JSON payloads and expose CV metadata

### DIFF
--- a/backend/ml/validation.py
+++ b/backend/ml/validation.py
@@ -1,0 +1,23 @@
+from sklearn.model_selection import LeaveOneOut, StratifiedKFold, KFold
+import numpy as np
+
+
+def build_cv(y, method: str, params: dict):
+    method = (method or "").upper()
+    y = np.array(y)
+
+    if method == "LOO":
+        cv = LeaveOneOut()
+        val_name = "LOO"
+        n_splits = len(y)
+    elif method == "STRATIFIEDKFOLD":
+        n_splits = int(params.get("n_splits", 5))
+        cv = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
+        val_name = "StratifiedKFold"
+    else:
+        n_splits = int(params.get("n_splits", 5))
+        cv = KFold(n_splits=n_splits, shuffle=True, random_state=42)
+        val_name = "KFold"
+
+    return cv, val_name, n_splits
+


### PR DESCRIPTION
## Summary
- add FastAPI exception handler to guide clients when sending non-JSON payloads
- provide cross-validation builder that surfaces method name and split count
- refactor `/optimize` and `/train` to accept JSON only and return validation metadata

## Testing
- `bash run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a099aba248832da81979079e167ff5