### PR TITLE
feat: add JSON API helper and improve Step4 UX

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,22 @@
+const API_BASE =
+  (typeof window !== 'undefined' && window.API_BASE) ||
+  `${location.protocol}//${location.hostname}:8000`;
+
+export async function postJSON(url, payload) {
+  const fullUrl = url.startsWith('http') ? url : `${API_BASE}${url}`;
+  const res = await fetch(fullUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const text = await res.text();
+  let data;
+  try { data = JSON.parse(text); } catch { data = { message: text }; }
+  if (!res.ok) {
+    const msg = data.detail?.[0]?.msg ?? data.detail?.msg ?? data.message ?? 'Erro na requisição';
+    throw new Error(msg);
+  }
+  return data;
+}
+
+export { API_BASE };


### PR DESCRIPTION
## Summary
- add generic postJSON helper for JSON API calls
- leverage postJSON in Step4Decision with busy state, spinner feedback, and improved polling
- fix mixed nullish/coalescing operators and label decision plot axes

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0a0a39900832db768f5a8838ac6d6