### PR TITLE
Enforce JSON payloads and improve CV builder

### DIFF
--- a/backend/ml/validation.py
+++ b/backend/ml/validation.py
@@ -1,23 +1,32 @@
 from sklearn.model_selection import LeaveOneOut, StratifiedKFold, KFold
 import numpy as np
+from sklearn.utils.multiclass import type_of_target
 
 
-def build_cv(y, method: str, params: dict):
-    method = (method or "").upper()
-    y = np.array(y)
+def is_classification(y: np.ndarray) -> bool:
+    t = type_of_target(y)
+    return t in ("binary", "multiclass")
+
+
+def build_cv(method: str, params: dict, y: np.ndarray):
+    method = (method or "KFold").upper()
+    params = params or {}
+    y = np.asarray(y)
 
     if method == "LOO":
         cv = LeaveOneOut()
-        val_name = "LOO"
-        n_splits = len(y)
+        splits = len(y)
+        return cv, {"method": "LOO", "splits": splits, "effective_splits": splits}
+    elif method == "KFOld" or method == "KFOLD":
+        n_splits = int(params.get("n_splits") or 5)
+        if is_classification(y):
+            cv = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
+        else:
+            cv = KFold(n_splits=n_splits, shuffle=True, random_state=42)
+        return cv, {"method": "KFold", "splits": n_splits, "effective_splits": n_splits}
     elif method == "STRATIFIEDKFOLD":
-        n_splits = int(params.get("n_splits", 5))
+        n_splits = int(params.get("n_splits") or 5)
         cv = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
-        val_name = "StratifiedKFold"
+        return cv, {"method": "StratifiedKFold", "splits": n_splits, "effective_splits": n_splits}
     else:
-        n_splits = int(params.get("n_splits", 5))
-        cv = KFold(n_splits=n_splits, shuffle=True, random_state=42)
-        val_name = "KFold"
-
-    return cv, val_name, n_splits
-
+        return build_cv("KFold", params, y)

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -149,27 +149,6 @@ export async function postPredict(payload) {
   return res.json();
 }
 
-// -------------------- FormData variant for /train --------------------
-export async function postTrainForm(fd) {
-
-  const urls = [
-    `${API_BASE}/train-form`,
-    `${API_BASE}/train`,
-    `${API_BASE}/analisar`,
-    `${API_BASE}/analyze`,
-  ];
-  let last;
-  for (const url of urls) {
-    try {
-      const res = await fetch(url, { method: 'POST', body: fd });
-      if (res.ok) return res.json();
-      if (res.status !== 404) throw new Error(await res.text());
-      last = new Error(`404 em ${url}`);
-    } catch (e) { last = e; }
-  }
-  throw last || new Error('Nenhuma rota de treino encontrada.');
-}
-
 const api = {
   postColumns,
   postOptimize,
@@ -181,7 +160,6 @@ const api = {
   predict,
   postPreprocess,
   postPredict,
-  postTrainForm,
 };
 
 export default api;


### PR DESCRIPTION
## Summary
- reject multipart requests with clear JSON error
- require application/json for /optimize and /train and parse validation params safely
- implement metadata-aware cross-validation builder with LOO support
- drop legacy /train-form usage and send JSON from frontend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a21790d0f4832d8e8449a3c8188292