### PR TITLE
fix: handle validation params and robust CV builder

### DIFF
--- a/backend/ml/validation.py
+++ b/backend/ml/validation.py
@@ -1,32 +1,64 @@
-from sklearn.model_selection import LeaveOneOut, StratifiedKFold, KFold
 import numpy as np
-from sklearn.utils.multiclass import type_of_target
+from sklearn.model_selection import LeaveOneOut, StratifiedKFold, KFold
 
 
-def is_classification(y: np.ndarray) -> bool:
-    t = type_of_target(y)
-    return t in ("binary", "multiclass")
+def build_cv_meta(method: str, params: dict, y):
+    """Constrói o objeto de validação e retorna (cv, meta).
 
+    Parameters
+    ----------
+    method : str
+        Nome do método solicitado (ex.: ``"LOO"``, ``"StratifiedKFold"``).
+    params : dict
+        Parâmetros adicionais para o construtor da validação. Atualmente
+        apenas ``n_splits`` é utilizado.
+    y : array-like
+        Vetor de respostas/alvos. Será convertido de forma segura para um
+        ``numpy.ndarray`` 1D.
 
-def build_cv(method: str, params: dict, y: np.ndarray):
-    method = (method or "KFold").upper()
+    Returns
+    -------
+    tuple
+        ``(cv, meta)`` onde ``cv`` é o objeto de validação pronto para uso e
+        ``meta`` é um ``dict`` com informações sobre o método efetivamente
+        utilizado, número de divisões e quantidade de amostras.
+    """
+
+    # Garantir vetor 1D com tamanho conhecido (evita "len() of unsized object")
+    y_arr = np.asarray(y).ravel()
+    n_samples = int(y_arr.shape[0])
+
+    method = (method or "").strip().upper()
     params = params or {}
-    y = np.asarray(y)
 
     if method == "LOO":
         cv = LeaveOneOut()
-        splits = len(y)
-        return cv, {"method": "LOO", "splits": splits, "effective_splits": splits}
-    elif method == "KFOld" or method == "KFOLD":
-        n_splits = int(params.get("n_splits") or 5)
-        if is_classification(y):
+        splits = n_samples
+        meta_method = "LOO"
+
+    elif method in {"SKF", "STRATIFIEDK", "STRATIFIEDKFOLD", "STRATIFIED"}:
+        n_splits = int(params.get("n_splits", 5)) if params else 5
+        classes, counts = np.unique(y_arr, return_counts=True)
+        # StratifiedKFold requer pelo menos duas classes e que cada uma tenha
+        # quantidade mínima de amostras para todas as dobras
+        if classes.size >= 2 and counts.min(initial=0) >= n_splits and n_splits >= 2:
             cv = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
+            splits = n_splits
+            meta_method = "StratifiedKFold"
         else:
-            cv = KFold(n_splits=n_splits, shuffle=True, random_state=42)
-        return cv, {"method": "KFold", "splits": n_splits, "effective_splits": n_splits}
-    elif method == "STRATIFIEDKFOLD":
-        n_splits = int(params.get("n_splits") or 5)
-        cv = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
-        return cv, {"method": "StratifiedKFold", "splits": n_splits, "effective_splits": n_splits}
+            # Fallback seguro para KFold quando estratificação não é possível
+            safe_splits = max(2, min(n_splits, n_samples))
+            cv = KFold(n_splits=safe_splits, shuffle=True, random_state=42)
+            splits = safe_splits
+            meta_method = "KFold(fallback)"
+
     else:
-        return build_cv("KFold", params, y)
+        n_splits = int(params.get("n_splits", 5)) if params else 5
+        safe_splits = max(2, min(n_splits, n_samples))
+        cv = KFold(n_splits=safe_splits, shuffle=True, random_state=42)
+        splits = safe_splits
+        meta_method = "KFold"
+
+    meta = {"method": meta_method, "splits": splits, "n_samples": n_samples}
+    return cv, meta
+


### PR DESCRIPTION
## Summary
- add robust cross-validation builder with safe y handling and Stratified/KFold fallback
- sanitize `y` and `validation_params` in training and optimization endpoints
- ensure request models always expose dict `validation_params`

## Testing
- `bash run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a222954520832daa729dd85b03d0f2