### PR TITLE
Deprecate legacy training route and enforce JSON payloads

### DIFF
--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -216,6 +216,7 @@ export default function Step4Decision({ step2, result, onBack, onContinue }) {
 
     try {
       const rangeStr = result?.params?.ranges || (spectralRange ? `${spectralRange[0]}-${spectralRange[1]}` : undefined);
+      const vp = step2.validation_params && typeof step2.validation_params === "object" ? step2.validation_params : {};
       const payload = {
         target: step2.target,
         n_components: step2.n_components,
@@ -223,7 +224,7 @@ export default function Step4Decision({ step2, result, onBack, onContinue }) {
         threshold: step2.threshold,
         n_bootstrap: 0,
         validation_method: step2.validation_method,
-        validation_params: step2.validation_params,
+        validation_params: vp,
         spectral_ranges: rangeStr
       };
       const res = await postJSON("/optimize", payload);
@@ -365,13 +366,14 @@ export default function Step4Decision({ step2, result, onBack, onContinue }) {
     setSaving(true);
     try {
       const rangeStr = result?.params?.ranges || (optData.range_used ? `${optData.range_used[0]}-${optData.range_used[1]}` : undefined);
+      const vp = step2.validation_params && typeof step2.validation_params === "object" ? step2.validation_params : {};
       await postJSON("/train", {
         target: step2.target,
         n_components: choice.n_components,
         classification: isClass,
         preprocess: choice.preprocess,
         validation_method: step2.validation_method,
-        validation_params: step2.validation_params,
+        validation_params: vp,
         spectral_ranges: rangeStr
       });
       onContinue?.(optData, { ...result?.params, n_components: choice.n_components, preprocess: choice.preprocess });

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -2,19 +2,23 @@ const API_BASE =
   (typeof window !== 'undefined' && window.API_BASE) ||
   `${location.protocol}//${location.hostname}:8000`;
 
-export async function postJSON(url, payload) {
-  const fullUrl = url.startsWith('http') ? url : `${API_BASE}${url}`;
+export async function postJSON(url, body) {
+  const fullUrl = url.startsWith("http") ? url : `${API_BASE}${url}`;
   const res = await fetch(fullUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload)
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
   });
   const text = await res.text();
-  let data;
-  try { data = JSON.parse(text); } catch { data = { message: text }; }
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    // keep raw text in case of debugging
+  }
   if (!res.ok) {
-    const msg = data.detail?.[0]?.msg ?? data.detail?.msg ?? data.message ?? 'Erro na requisição';
-    throw new Error(msg);
+    const detail = data && (data.detail || data.message);
+    throw new Error(detail ? detail : `HTTP ${res.status}: ${text}`);
   }
   return data;
 }


### PR DESCRIPTION
## Summary
- deprecate `/train-form` and require application/json for training and optimization
- extend `/train` and `/optimize` responses with validation, spectral info and best model metadata
- ensure frontend requests send real JSON bodies with proper helper

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22f9fbd44832d8bdddda90e7cd08f