### PR TITLE
feat: persistent dataset upload and JSON training flow

### DIFF
--- a/backend/core/dataset_store.py
+++ b/backend/core/dataset_store.py
@@ -1,0 +1,88 @@
+"""Thread-safe in-memory dataset storage.
+
+This module provides a very small utility used by the API endpoints to
+temporarily persist uploaded datasets.  Each dataset is stored as a
+``pandas.DataFrame`` and referenced by a random UUID.  The store behaves like
+an in-memory LRU cache – recent datasets are kept while older entries can be
+evicted to prevent unbounded memory growth.  For the current use cases a very
+small cache is enough, therefore the implementation below keeps the last
+``MAX_ITEMS`` datasets.
+
+The interface intentionally mirrors a tiny subset of what would be provided by
+an external cache (Redis, Memcached, …).  Only two operations are required:
+
+``put(df)``
+    Store the given DataFrame and return the generated ``dataset_id``.
+
+``get(dataset_id)``
+    Retrieve a previously stored DataFrame or ``None`` when the id is
+    unknown/expired.
+
+The object is implemented as a singleton so multiple modules can import and
+use ``DatasetStore()`` without explicitly sharing state.  All operations are
+protected by a re-entrant lock making them safe to use from async endpoints
+running in different threads.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+import threading
+import uuid
+from typing import Optional
+
+import pandas as pd
+
+
+class DatasetStore:
+    """Singleton, thread-safe cache of uploaded datasets."""
+
+    # Rough safeguard to avoid holding too many large DataFrames in memory.
+    MAX_ITEMS = 8
+
+    _instance: "DatasetStore | None" = None
+    _instance_lock = threading.Lock()
+
+    def __new__(cls) -> "DatasetStore":
+        # Standard singleton pattern with double-checked locking
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance._data = OrderedDict()  # type: ignore[attr-defined]
+                    cls._instance._lock = threading.RLock()  # type: ignore[attr-defined]
+        return cls._instance
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def put(self, df: pd.DataFrame) -> str:
+        """Store ``df`` and return a new UUID string."""
+
+        dataset_id = uuid.uuid4().hex
+        with self._lock:  # type: ignore[attr-defined]
+            self._data[dataset_id] = df  # type: ignore[index]
+            self._data.move_to_end(dataset_id)  # LRU behaviour
+            # Drop the oldest item if cache grows too big
+            if len(self._data) > self.MAX_ITEMS:  # type: ignore[attr-defined]
+                self._data.popitem(last=False)
+        return dataset_id
+
+    def get(self, dataset_id: str) -> Optional[pd.DataFrame]:
+        """Return the DataFrame associated with ``dataset_id`` or ``None``."""
+
+        with self._lock:  # type: ignore[attr-defined]
+            df = self._data.get(dataset_id)  # type: ignore[attr-defined]
+            if df is not None:
+                # Touch item to keep it as most recently used
+                self._data.move_to_end(dataset_id)  # type: ignore[attr-defined]
+        return df
+
+
+# Convenience function mirroring a typical ``get_instance`` API
+def get_store() -> DatasetStore:
+    return DatasetStore()
+
+
+__all__ = ["DatasetStore", "get_store"]
+

--- a/backend/tests/test_dataset_flow.py
+++ b/backend/tests/test_dataset_flow.py
@@ -1,0 +1,46 @@
+import pandas as pd
+from fastapi.testclient import TestClient
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_upload_preprocess_and_train(tmp_path):
+    df = pd.DataFrame({"1100": [1, 2, 3, 4], "1200": [2, 4, 6, 8], "target": [0, 1, 0, 1]})
+    path = tmp_path / "data.csv"
+    df.to_csv(path, index=False)
+    with open(path, "rb") as fh:
+        resp = client.post("/dataset/upload", files={"file": ("data.csv", fh.read(), "text/csv")})
+    assert resp.status_code == 200
+    dataset_id = resp.json()["dataset_id"]
+    assert dataset_id
+
+    resp = client.post(
+        "/preprocess",
+        json={"dataset_id": dataset_id, "target": "target", "spectral_ranges": "1100-1200"},
+    )
+    assert resp.status_code == 200
+    cols = resp.json()["columns"]
+    assert "1100" in cols and "1200" in cols
+
+    train_payload = {
+        "dataset_id": dataset_id,
+        "target": "target",
+        "analysis_mode": "PLS-DA",
+        "n_components": 2,
+        "preprocess": [],
+        "spectral_ranges": "1100-1200",
+        "validation_method": "LOO",
+        "decision_mode": "argmax",
+    }
+    resp = client.post("/train", json=train_payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "model_id" in data
+


### PR DESCRIPTION
## Summary
- add thread-safe `DatasetStore` and `/dataset/upload` endpoint
- accept dataset IDs in new `/preprocess`, `/optimize`, and `/train` JSON APIs
- introduce robust CV helper and safer preprocessing

## Testing
- `pytest`
- `pytest tests/test_dataset_flow.py::test_upload_preprocess_and_train -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3286690dc832db42406f617d01ab2