### PR TITLE
Handle dataset lookup for /columns and propagate dataset_id to frontend

### DIFF
--- a/frontend/src/api/http.js
+++ b/frontend/src/api/http.js
@@ -1,5 +1,5 @@
 // --- dataset id helpers ---
-const DS_KEY = "nir.dataset_id";
+const DS_KEY = "dataset_id";
 
 export function setDatasetId(id) {
   try {

--- a/frontend/src/components/nir/Step1Upload.jsx
+++ b/frontend/src/components/nir/Step1Upload.jsx
@@ -1,5 +1,4 @@
 import { useState, useRef } from "react";
-import { setDatasetId } from "../../api/http";
 
 export default function Step1Upload({ onSuccess }) {
   const [progress, setProgress] = useState(0);
@@ -67,7 +66,7 @@ export default function Step1Upload({ onSuccess }) {
           setError("Não foi possível interpretar a resposta do servidor.");
           return;
         }
-        if (meta?.dataset_id) setDatasetId(meta.dataset_id);
+        if (meta?.dataset_id) localStorage.setItem("dataset_id", meta.dataset_id);
         onSuccess({ file, meta });
       } else {
         const msg =


### PR DESCRIPTION
## Summary
- Use DatasetStore for `/columns`, returning candidate targets and features with fallback to last dataset
- Improve validation hints and log dataset info in `/optimize` and `/train`
- Save and send `dataset_id` automatically on the frontend
- Update tests for new `/columns` behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3622165e0832d8e47cdd40771d58d