### PR TITLE
feat: use dataset metadata cache

### DIFF
--- a/backend/tests/test_dataset_flow.py
+++ b/backend/tests/test_dataset_flow.py
@@ -18,8 +18,20 @@ def test_upload_preprocess_and_train(tmp_path):
     with open(path, "rb") as fh:
         resp = client.post("/columns", files={"file": ("data.csv", fh.read(), "text/csv")})
     assert resp.status_code == 200
-    dataset_id = resp.json()["dataset_id"]
+    data = resp.json()
+    dataset_id = data["dataset_id"]
     assert dataset_id
+    assert "spectra_matrix" not in data
+    assert data["n_samples"] == 4
+    assert data["n_wavelengths"] == 2
+    assert data["wl_min"] == 1100.0
+    assert data["wl_max"] == 1200.0
+
+    meta_resp = client.get(f"/columns/meta?dataset_id={dataset_id}")
+    assert meta_resp.status_code == 200
+    meta = meta_resp.json()
+    assert meta["columns"] == ["1100", "1200"]
+    assert meta["targets"] == ["target"]
 
     resp = client.post(
         "/preprocess",

--- a/frontend/src/NirPage.jsx
+++ b/frontend/src/NirPage.jsx
@@ -8,7 +8,6 @@ import Step5Result from "./components/nir/Step5Result.jsx";
 
 export default function NirPage() {
   const [step, setStep] = useState(1);
-  const [file, setFile] = useState(null);
   const [meta, setMeta] = useState(null);
   const [step2, setStep2] = useState(null);
   const [result, setResult] = useState(null);
@@ -16,7 +15,6 @@ export default function NirPage() {
 
   function resetAll() {
     setStep(1);
-    setFile(null);
     setMeta(null);
     setStep2(null);
     setResult(null);
@@ -52,8 +50,7 @@ export default function NirPage() {
         {/* Steps */}
         {step === 1 && (
           <Step1Upload
-            onSuccess={({ file, meta }) => {
-              setFile(file);
+            onSuccess={({ meta }) => {
               setMeta(meta);
               setStep(2);
             }}
@@ -62,7 +59,6 @@ export default function NirPage() {
 
         {step === 2 && (
           <Step2Parameters
-            meta={meta}
             onBack={() => setStep(1)}
             onNext={(params) => {
               setStep2(params);
@@ -73,7 +69,6 @@ export default function NirPage() {
 
         {step === 3 && (
           <Step3Preprocess
-            file={file}
             meta={meta}
             step2={step2}
             onBack={() => setStep(2)}

--- a/frontend/src/components/nir/Step1Upload.jsx
+++ b/frontend/src/components/nir/Step1Upload.jsx
@@ -67,12 +67,23 @@ export default function Step1Upload({ onSuccess }) {
           setError("Não foi possível interpretar a resposta do servidor.");
           return;
         }
-        if (meta?.dataset_id) {
-          localStorage.setItem("nir.datasetId", meta.dataset_id);
-          localStorage.setItem("nir.columns", JSON.stringify(meta.columns || []));
-          localStorage.setItem("nir.targets", JSON.stringify(meta.targets || []));
-          setDatasetId(meta.dataset_id);
+        if (!meta?.dataset_id || !meta?.columns?.length || !meta?.targets?.length) {
+          setError("Resposta de /columns inválida. Tente reenviar o arquivo.");
+          return;
         }
+        localStorage.setItem("nir.datasetId", meta.dataset_id);
+        localStorage.setItem("nir.columns", JSON.stringify(meta.columns || []));
+        localStorage.setItem("nir.targets", JSON.stringify(meta.targets || []));
+        localStorage.setItem(
+          "nir.meta",
+          JSON.stringify({
+            n_samples: meta.n_samples,
+            n_wavelengths: meta.n_wavelengths,
+            wl_min: meta.wl_min,
+            wl_max: meta.wl_max,
+          })
+        );
+        setDatasetId(meta.dataset_id);
         onSuccess({ file, meta });
       } else {
         const msg =

--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -205,7 +205,7 @@ export default function Step4Decision({ step2, result, onBack, onContinue }) {
 
   async function handleOptimize() {
     if (!getDatasetId()) {
-      alert("Nenhum dataset carregado. Faça o upload antes de otimizar.");
+      alert("Dataset não encontrado — volte ao passo 1 e faça o upload.");
       return;
     }
     setError("");
@@ -252,10 +252,10 @@ export default function Step4Decision({ step2, result, onBack, onContinue }) {
       if (pollRef.current) clearTimeout(pollRef.current);
     } catch (e) {
       const msg = e?.message || String(e);
-      if (msg.includes("Nenhum dataset carregado")) {
-        alert("Suba o arquivo na etapa 1 (Upload) e tente novamente.");
+      if (msg.includes("Nenhum dataset") || msg.includes("dataset_id")) {
+        alert("Dataset não encontrado. Volte ao passo 1 e faça o upload.");
       } else if (msg.includes("415")) {
-        alert("Esta etapa usa JSON; o upload de arquivo é só no Upload.");
+        alert("Requisição inválida. Envie JSON (Content-Type: application/json).");
       } else {
         setError(typeof e === "string" ? e : msg || "Falha na otimização.");
       }
@@ -371,7 +371,7 @@ export default function Step4Decision({ step2, result, onBack, onContinue }) {
   /* ===== Continuar ===== */
   async function handleTrainWithSelection(){
     if (!getDatasetId()) {
-      alert("Nenhum dataset carregado. Faça o upload antes de treinar.");
+      alert("Dataset não encontrado — volte ao passo 1 e faça o upload.");
       return;
     }
     if(selected == null || !optData) return; setError("");
@@ -393,10 +393,10 @@ export default function Step4Decision({ step2, result, onBack, onContinue }) {
       onContinue?.(optData, { ...result?.params, n_components: choice.n_components, preprocess: choice.preprocess });
     } catch (e) {
       const msg = e?.message || String(e);
-      if (msg.includes("Nenhum dataset carregado")) {
-        alert("Suba o arquivo na etapa 1 (Upload) e tente novamente.");
+      if (msg.includes("Nenhum dataset") || msg.includes("dataset_id")) {
+        alert("Dataset não encontrado. Volte ao passo 1 e faça o upload.");
       } else if (msg.includes("415")) {
-        alert("Esta etapa usa JSON; o upload de arquivo é só no Upload.");
+        alert("Requisição inválida. Envie JSON (Content-Type: application/json).");
       } else {
         setError(typeof e === "string" ? e : (msg || "Erro ao executar modelagem final."));
       }


### PR DESCRIPTION
## Summary
- store spectral matrix separately and return lightweight metadata from `/columns`
- cache dataset metadata in localStorage and reload via `/columns/meta`
- always send `dataset_id` as JSON and show friendly messages on errors

## Testing
- `cd backend && pytest`
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a383606e84832dabf14a9a01b0321c