### PR TITLE
feat: refine dataset store and training workflow

### DIFF
--- a/backend/dataset_store.py
+++ b/backend/dataset_store.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+import pandas as pd
+from typing import Dict, Any, Optional
+from utils.targets import pick_column_ci, normalize_series_for_target
+
+class DatasetStore:
+    def __init__(self):
+        self._data: Dict[str, Dict[str, Any]] = {}
+
+    def save(self, dataset_id: str, payload: Dict[str, Any]):
+        self._data[dataset_id] = payload   # não alterar tipos aqui
+
+    def get(self, dataset_id: str) -> Dict[str, Any]:
+        return self._data.get(dataset_id, {})
+
+    def get_target(self, dataset_id: str, target_name: str):
+        ds = self.get(dataset_id)
+        ydf: Optional[pd.DataFrame] = ds.get("y_df")
+        if ydf is None: return None
+        col = pick_column_ci(ydf, target_name)
+        if col is None: return None
+        s = normalize_series_for_target(ydf[col])
+        return s.to_numpy()               # dtype=object quando houver strings (E01, ...)

--- a/backend/pls.py
+++ b/backend/pls.py
@@ -1,0 +1,3 @@
+from core.optimization import make_pls_reg, make_pls_da
+
+__all__ = ["make_pls_reg", "make_pls_da"]

--- a/backend/validation.py
+++ b/backend/validation.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+import numpy as np
+from sklearn.model_selection import KFold, StratifiedKFold, LeaveOneOut
+
+def build_cv(validation_method: str, y=None, n_splits: int = 5, stratified: bool = True, random_state: int = 42):
+    method = (validation_method or "").upper()
+    if method in {"LOO", "LEAVE-ONE-OUT", "LEAVE ONE OUT"}:
+        return LeaveOneOut()
+
+    if y is None:
+        return KFold(n_splits=max(2, int(n_splits or 5)), shuffle=True, random_state=random_state)
+
+    y = np.asarray(y)
+    if stratified:
+        _, counts = np.unique(y, return_counts=True)
+        max_splits = int(np.min(counts))
+        safe = max(2, min(int(n_splits or 5), max_splits))
+        return StratifiedKFold(n_splits=safe, shuffle=True, random_state=random_state)
+    else:
+        return KFold(n_splits=max(2, min(int(n_splits or 5), y.shape[0])), shuffle=True, random_state=random_state)


### PR DESCRIPTION
## Summary
- avoid type casting target columns in in-memory dataset store
- revamp `/columns` to persist target DataFrames and return spectra matrix
- simplify `/train` with robust PLS-DA handling for string labels
- add reusable cross-validation builder supporting LOO and StratifiedKFold

## Testing
- `pytest tests/` *(fails: AssertionError: assert 'numcat' in ['cat']; assert 3 == 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d717ab64832d9574e36bd199e950