### PR TITLE
Implement PLS factories, optimizer, and preprocessing

### DIFF
--- a/backend/optimization.py
+++ b/backend/optimization.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import Dict, Any, Iterable
+from sklearn.metrics import accuracy_score, roc_auc_score, mean_squared_error
+
+from utils.task_detect import detect_task_from_y
+from utils.sanitize import sanitize_X, sanitize_y, align_X_y, limit_n_components
+from validation import build_cv
+from pls import make_pls_reg, make_pls_da
+
+
+def optimize_model_grid(
+    X: np.ndarray,
+    y: np.ndarray,
+    grid: Dict[str, Iterable[Any]],
+    mode: str,
+    validation_method: str = "KFold",
+    n_splits: int = 5,
+    random_state: int = 42,
+) -> Dict[str, Any]:
+    """Evaluate PLS models over a grid of ``n_components`` values.
+
+    The function is robust against invalid combinations: when an error occurs
+    during cross-validation for a specific number of components the exception is
+    caught and recorded while the search continues. It supports both regression
+    and classification tasks, automatically selecting between PLSR and PLS-DA.
+    """
+
+    out: Dict[str, Any] = {"status": "error", "message": "sem avaliação", "history": []}
+
+    task = detect_task_from_y(y, mode)
+    X = sanitize_X(X)
+    y, classes_ = sanitize_y(y, task)
+    X, y, _ = align_X_y(X, y)
+    if X.shape[0] == 0:
+        return {"status": "error", "message": "Sem amostras após sanitização."}
+
+    cv = build_cv(
+        validation_method,
+        y=y,
+        n_splits=n_splits,
+        stratified=(task == "classification"),
+    )
+
+    ncomp_list = list(grid.get("n_components", [2]))
+    best_score = -np.inf if task == "classification" else np.inf
+
+    for ncomp in ncomp_list:
+        scores = []
+        try:
+            for tr, te in cv.split(X, y):
+                Xtr, Xte = X[tr], X[te]
+                ytr, yte = y[tr], y[te]
+                safe_n = limit_n_components(int(ncomp), Xtr)
+                if safe_n < 1:
+                    continue
+
+                if task == "classification":
+                    model = make_pls_da(
+                        n_components=safe_n,
+                        n_classes=int(np.unique(y).size),
+                    )
+                    model.fit(Xtr, ytr.astype(int))
+                    if hasattr(model, "predict_proba"):
+                        proba = model.predict_proba(Xte)
+                        if proba.shape[1] == 2:
+                            score = roc_auc_score(yte, proba[:, 1])
+                        else:
+                            pred = np.argmax(proba, axis=1)
+                            score = accuracy_score(yte, pred)
+                    else:
+                        pred = model.predict(Xte).ravel()
+                        if np.unique(y).size <= 2:
+                            score = accuracy_score(yte, (pred >= 0.5).astype(int))
+                        else:
+                            score = accuracy_score(yte, np.rint(pred).astype(int))
+                else:
+                    model = make_pls_reg(n_components=safe_n).fit(Xtr, ytr)
+                    pred = model.predict(Xte).ravel()
+                    score = -np.sqrt(mean_squared_error(yte, pred))
+
+                scores.append(float(score))
+        except Exception as e:  # pragma: no cover - log errors
+            out["history"].append({"n_components": int(ncomp), "error": str(e)})
+            continue
+
+        if not scores:
+            continue
+
+        mean_score = float(np.mean(scores))
+        out["history"].append({"n_components": int(ncomp), "cv_score": mean_score})
+        better = mean_score > best_score if task == "classification" else mean_score < best_score
+        if better:
+            best_score = mean_score
+            out.update(
+                {
+                    "status": "ok",
+                    "best_params": {"n_components": int(ncomp)},
+                    "best_score": mean_score,
+                    "task": task,
+                    "classes_": classes_ or [],
+                    "validation_method": validation_method,
+                }
+            )
+
+    if out.get("status") != "ok":
+        out["message"] = "Nenhuma combinação válida avaliada."
+    return out
+
+
+__all__ = ["optimize_model_grid"]
+

--- a/backend/pls.py
+++ b/backend/pls.py
@@ -1,3 +1,42 @@
-from core.optimization import make_pls_reg, make_pls_da
+from __future__ import annotations
+
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.multiclass import OneVsRestClassifier
+from typing import Any
+
+
+def make_pls_reg(n_components: int = 2, **kwargs) -> PLSRegression:
+    """Create a PLSRegression model.
+
+    Parameters
+    ----------
+    n_components: int, default=2
+        Number of latent components.
+    **kwargs: Any
+        Extra keyword arguments passed to ``PLSRegression``.
+    """
+
+    return PLSRegression(n_components=n_components, **kwargs)
+
+
+def make_pls_da(
+    n_components: int = 2,
+    n_classes: int | None = None,
+    **kwargs,
+) -> Any:
+    """Factory for PLS-DA models.
+
+    When ``n_classes`` is greater than two, a one-vs-rest scheme with
+    ``PLSRegression`` as the base estimator is used. Otherwise, a single
+    ``PLSRegression`` instance is returned. Additional keyword arguments are
+    forwarded to ``PLSRegression``.
+    """
+
+    if n_classes is not None and n_classes > 2:
+        base = PLSRegression(n_components=n_components, **kwargs)
+        return OneVsRestClassifier(base)
+    return PLSRegression(n_components=n_components, **kwargs)
+
 
 __all__ = ["make_pls_reg", "make_pls_da"]
+

--- a/backend/preprocessing.py
+++ b/backend/preprocessing.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import savgol_filter
+
+
+def snv(X: np.ndarray) -> np.ndarray:
+    """Standard normal variate."""
+    m = X.mean(axis=1, keepdims=True)
+    s = X.std(axis=1, keepdims=True)
+    s[s == 0] = 1.0
+    return (X - m) / s
+
+
+def msc(X: np.ndarray) -> np.ndarray:
+    """Multiplicative scatter correction."""
+    ref = X.mean(axis=0, keepdims=True)
+    out = np.empty_like(X)
+    for i in range(X.shape[0]):
+        b = np.polyfit(ref.ravel(), X[i], 1)
+        out[i] = (X[i] - b[1]) / b[0]
+    return out
+
+
+def sg1(X: np.ndarray, window: int = 11, poly: int = 2) -> np.ndarray:
+    """Savitzky-Golay first derivative."""
+    return savgol_filter(X, window_length=window, polyorder=poly, deriv=1, axis=1)
+
+
+def sg0(X: np.ndarray, window: int = 11, poly: int = 2) -> np.ndarray:
+    """Savitzky-Golay smoothing (zero derivative)."""
+    return savgol_filter(X, window_length=window, polyorder=poly, deriv=0, axis=1)
+
+
+def apply_preprocessing(X: np.ndarray, ops: dict) -> np.ndarray:
+    """Apply selected preprocessing operations to ``X``.
+
+    ``ops`` is a mapping where keys such as ``"SNV"``, ``"MSC"``, ``"SG1```` and
+    ``"SG0"`` enable the respective operations. Values associated with ``SG1`` or
+    ``SG0`` may themselves be dictionaries specifying ``window`` and ``poly``
+    parameters. The result is always a float ``ndarray`` where infinite values are
+    converted to ``NaN``.
+    """
+
+    Z = X
+    if ops.get("SNV"):
+        Z = snv(Z)
+    if ops.get("MSC"):
+        Z = msc(Z)
+    if ops.get("SG1"):
+        c = ops["SG1"] or {}
+        Z = sg1(Z, window=int(c.get("window", 11)), poly=int(c.get("poly", 2)))
+    if ops.get("SG0"):
+        c = ops["SG0"] or {}
+        Z = sg0(Z, window=int(c.get("window", 11)), poly=int(c.get("poly", 2)))
+
+    Z = np.array(Z, dtype=float)
+    Z[np.isinf(Z)] = np.nan
+    return Z
+
+
+__all__ = ["snv", "msc", "sg1", "sg0", "apply_preprocessing"]
+


### PR DESCRIPTION
## Summary
- add `make_pls_reg` and `make_pls_da` helpers to build PLSR/PLS‑DA models
- introduce `optimize_model_grid` for robust PLS component selection
- provide preprocessing utilities (SNV, MSC, Savitzky–Golay) with safe numeric outputs
- enhance `/columns` endpoint to classify numeric targets and expose dataset metadata; `/train` now returns a saved model id

## Testing
- `cd backend && bash run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b5d8a6a75c832db6973268c1489cd3