### PR TITLE
Fix columns payload and align frontend train parameters

### DIFF
--- a/backend/tests/test_dataset_flow.py
+++ b/backend/tests/test_dataset_flow.py
@@ -22,8 +22,8 @@ def test_upload_preprocess_and_train(tmp_path):
     dataset_id = data["dataset_id"]
     assert dataset_id
     assert "spectra_matrix" in data
-    assert len(data["spectra_matrix"]) == 4
-    assert len(data["spectra_matrix"][0]) == 2
+    assert len(data["spectra_matrix"]["values"]) == 4
+    assert len(data["spectra_matrix"]["values"][0]) == 2
 
     meta_resp = client.get(f"/columns/meta?dataset_id={dataset_id}")
     assert meta_resp.status_code == 200
@@ -42,7 +42,7 @@ def test_upload_preprocess_and_train(tmp_path):
     train_payload = {
         "dataset_id": dataset_id,
         "target_name": "target",
-        "mode": "PLS-DA",
+        "mode": "classification",
         "n_components": 2,
     }
     resp = client.post("/train", json=train_payload)

--- a/frontend/src/components/nir/Step2Parameters.jsx
+++ b/frontend/src/components/nir/Step2Parameters.jsx
@@ -144,7 +144,6 @@ function DecimalChooser({
 
 export default function Step2Parameters({ onBack, onNext }) {
   const [targets, setTargets] = useState([]);
-  const [features, setFeatures] = useState([]);
   const [error, setError] = useState("");
 
   const [target, setTarget] = useState("");
@@ -166,7 +165,6 @@ export default function Step2Parameters({ onBack, onNext }) {
     const cachedCols = JSON.parse(localStorage.getItem("nir.columns") || "[]");
     if (cachedTargets.length && cachedCols.length) {
       setTargets(cachedTargets);
-      setFeatures(cachedCols);
       setTarget((t) => t || cachedTargets[0] || "");
       return;
     }
@@ -187,14 +185,12 @@ export default function Step2Parameters({ onBack, onNext }) {
           })
         );
         setTargets(meta.targets);
-        setFeatures(meta.columns);
         setTarget(meta.targets[0] || "");
         setError(null);
       })
       .catch(() => {
         setError("Erro ao recuperar metadados. Refaça o upload no passo 1.");
         setTargets([]);
-        setFeatures([]);
       });
   }, []);
 

--- a/frontend/src/components/nir/Step3Preprocess.jsx
+++ b/frontend/src/components/nir/Step3Preprocess.jsx
@@ -148,8 +148,6 @@ export default function Step3Preprocess({ meta, step2, onBack, onAnalyzed }) {
 
   async function runAnalysis(e) {
     e.preventDefault();
-    const ds = getDatasetId();
-    if (!ds) return alert("Dataset não encontrado — volte ao passo 1 e faça o upload.");
     if (!ranges.length) return alert("Selecione ao menos uma faixa.");
 
     setRunning(true);
@@ -161,10 +159,13 @@ export default function Step3Preprocess({ meta, step2, onBack, onAnalyzed }) {
 
       const rangesStr = ranges.map(([a, b]) => `${a}-${b}`).join(",");
 
+      const dsId = getDatasetId();
+      if (!dsId) throw new Error("Dataset não encontrado. Volte ao passo 1 e reenvie o arquivo.");
       const payload = {
-        target: step2.target,
+        dataset_id: dsId,
+        target_name: step2.target,               // backend espera 'target_name'
+        mode: step2.classification ? "classification" : "regression",  // backend espera 'mode'
         n_components: step2.n_components,
-        classification: step2.classification,
         threshold: step2.classification && step2.threshold != null ? step2.threshold : undefined,
         n_bootstrap: step2.n_bootstrap ?? 0,
         validation_method: step2.validation_method,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,5 @@
 
-import { postJSON } from "../api/http";
+import { postJSON, getDatasetId } from "../api/http";
 
 const DEFAULT_API_BASE =
   typeof location !== 'undefined'
@@ -120,7 +120,8 @@ export async function postPreprocess(payload) {
 
 
 export async function postTrain(payload) {
-  return postJSON(`${API_BASE}/train`, payload);
+  const ds = payload?.dataset_id || getDatasetId();
+  return postJSON(`${API_BASE}/train`, { dataset_id: ds, ...payload });
 }
 
 


### PR DESCRIPTION
## Summary
- Return structured spectra metadata from `/columns` with wavelengths and stats
- Include dataset id and updated field names when training from Step3
- Ensure service-level train calls send dataset_id
- Remove unused features state in parameters step

## Testing
- `cd backend && pytest tests`
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b73822b7a8832dadcbcbc026044bc5