### PR TITLE
feat: expose normalized confusion matrix and new NIR cards

### DIFF
--- a/frontend/src/components/nir/ConfusionMatrixCard.jsx
+++ b/frontend/src/components/nir/ConfusionMatrixCard.jsx
@@ -1,0 +1,49 @@
+// frontend/src/components/nir/ConfusionMatrixCard.jsx
+import React from "react";
+
+function Cell({ value, frac }) {
+  const bg = Number.isFinite(frac) ? `rgba(16, 185, 129, ${Math.min(1, Math.max(0.05, frac))})` : "transparent";
+  return (
+    <td style={{ background: bg }} className="text-center">{value}</td>
+  );
+}
+
+export default function ConfusionMatrixCard({ cm }) {
+  if (!cm?.labels?.length || !cm?.matrix?.length) {
+    return (
+      <div className="card dashed h-64 flex items-center justify-center">
+        <p>Não disponível para este modo/validação.</p>
+      </div>
+    );
+  }
+
+  const labels = cm.labels;
+  const M = cm.matrix;
+  const N = cm.normalized;
+
+  return (
+    <div className="card p-4">
+      <h3 className="card-title mb-3">Matriz de Confusão</h3>
+      <div className="overflow-x-auto">
+        <table className="table table-sm">
+          <thead>
+            <tr>
+              <th>Verdadeiro \ Predito</th>
+              {labels.map((l, j) => <th key={j} className="text-center">{l}</th>)}
+            </tr>
+          </thead>
+          <tbody>
+            {M.map((row, i) => (
+              <tr key={i}>
+                <th>{labels[i]}</th>
+                {row.map((v, j) => (
+                  <Cell key={j} value={v} frac={N ? N[i][j] : null} />
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/nir/VipTopCard.jsx
+++ b/frontend/src/components/nir/VipTopCard.jsx
@@ -1,0 +1,40 @@
+// frontend/src/components/nir/VipTopCard.jsx
+import React from "react";
+
+export default function VipTopCard({ vip = [], top = 20, title = "VIPs (Top)" }) {
+  const topVip = vip.slice(0, top);
+
+  if (!topVip.length) {
+    return (
+      <div className="card dashed h-64 flex items-center justify-center">
+        <p>Sem VIPs disponíveis para esta calibração.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card p-4">
+      <h3 className="card-title mb-3">{title}</h3>
+      <div className="overflow-x-auto">
+        <table className="table table-sm">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>λ (nm)</th>
+              <th>VIP</th>
+            </tr>
+          </thead>
+          <tbody>
+            {topVip.map((d, i) => (
+              <tr key={i}>
+                <td>{i + 1}</td>
+                <td>{Number(d.wavelength).toFixed(2)}</td>
+                <td>{Number(d.score).toFixed(4)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/normalizeTrainResult.js
+++ b/frontend/src/services/normalizeTrainResult.js
@@ -1,0 +1,50 @@
+// frontend/src/services/normalizeTrainResult.js
+export function extractVip(res) {
+  // tenta { vip: {wavelengths, scores} }
+  if (res?.vip?.scores?.length) {
+    const wl = res.vip.wavelengths || res.wavelengths || [];
+    return res.vip.scores.map((score, i) => ({
+      wavelength: Number(wl?.[i] ?? i),
+      score: Number(score),
+    })).filter(d => Number.isFinite(d.score));
+  }
+  // tenta [{ wavelength, score }]
+  if (Array.isArray(res?.vips) && res.vips.length) {
+    return res.vips.map(d => ({
+      wavelength: Number(d.wavelength),
+      score: Number(d.score),
+    })).filter(d => Number.isFinite(d.score));
+  }
+  // nada
+  return [];
+}
+
+export function extractConfusion(res) {
+  if (res?.confusion_matrix?.matrix) {
+    const labels = res.confusion_matrix.labels || [];
+    const matrix = res.confusion_matrix.matrix || [];
+    const normalized = res.confusion_matrix.normalized || null;
+    return { labels, matrix, normalized };
+  }
+  // formatos antigos opcionais
+  if (res?.cm && res?.labels) {
+    return { labels: res.labels, matrix: res.cm, normalized: null };
+  }
+  return null;
+}
+
+export function normalizeTrainResult(res) {
+  const vip = extractVip(res)
+    .sort((a, b) => b.score - a.score);
+  const cm = extractConfusion(res);
+
+  return {
+    task: res?.task || "classification",
+    metrics: res?.metrics || {},
+    cv: res?.cv || {},
+    vip,
+    cm,
+    wavelengths: res?.wavelengths || [],
+    oof: res?.oof || null,
+  };
+}


### PR DESCRIPTION
## Summary
- return row-normalized confusion matrix and OOF predictions from `/train`
- add normalization utility and cards for VIP Top and Confusion Matrix
- integrate new cards into Step4Decision

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b871d79138832dbff4dd1292d2b917