### PR TITLE
feat: expand training metrics and UI

### DIFF
--- a/frontend/src/components/nir/LatentCard.jsx
+++ b/frontend/src/components/nir/LatentCard.jsx
@@ -20,7 +20,7 @@ export default function LatentCard({ latent, labels }) {
       <h3 className="card-title mb-3">Latentes (Scores LV1 × LV2)</h3>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <div className="col-span-1">
-          <ResponsiveContainer width="100%" height={260}>
+          <ResponsiveContainer width="100%" height={320}>
             <ScatterChart>
               <CartesianGrid />
               <XAxis type="number" dataKey="lv1" name="LV1" />

--- a/frontend/src/components/nir/PerClassMetricsCard.jsx
+++ b/frontend/src/components/nir/PerClassMetricsCard.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+export default function PerClassMetricsCard({ perClass }) {
+  if (!perClass?.length) return null;
+  return (
+    <div className="card p-4">
+      <h3 className="card-title mb-3">Métricas por Classe</h3>
+      <div className="overflow-x-auto" style={{maxHeight: 280, overflowY:"auto"}}>
+        <table className="table table-sm">
+          <thead><tr><th>Classe</th><th>Precisão</th><th>Recall</th><th>F1</th><th>Suporte</th></tr></thead>
+          <tbody>
+            {perClass.map((r, i) => (
+              <tr key={i}>
+                <td>{r.label}</td>
+                <td>{r.precision.toFixed(3)}</td>
+                <td>{r.recall.toFixed(3)}</td>
+                <td>{r.f1.toFixed(3)}</td>
+                <td>{r.support}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -6,6 +6,7 @@ import VipTopCard from "./VipTopCard";
 import ConfusionMatrixCard from "./ConfusionMatrixCard";
 import CvCurveCard from "./CvCurveCard";
 import LatentCard from "./LatentCard";
+import PerClassMetricsCard from "./PerClassMetricsCard";
 import { normalizeTrainResult } from "../../services/normalizeTrainResult";
 
 /* ===== Helpers ===== */
@@ -462,10 +463,12 @@ export default function Step4Decision({ step2, result, onBack, onContinue }) {
               <ConfusionMatrixCard cm={data.cm} />
             </div>
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
               <CvCurveCard curve={data.cv_curve} task={data.task} />
-              <LatentCard latent={data.latent} labels={data.oof?.labels} />
+              <LatentCard latent={data.latent} labels={data.latent?.sample_labels} />
             </div>
+
+            <PerClassMetricsCard perClass={data.per_class} />
           </div>
 
         </div>

--- a/frontend/src/components/nir/VipTopCard.jsx
+++ b/frontend/src/components/nir/VipTopCard.jsx
@@ -15,7 +15,7 @@ export default function VipTopCard({ vip = [], top = 30, title = "VIPs (Top)" })
   return (
     <div className="card p-4">
       <h3 className="card-title mb-3">{title}</h3>
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto" style={{maxHeight: 360, overflowY: "auto"}}>
         <table className="table table-sm">
           <thead>
             <tr>

--- a/frontend/src/services/normalizeTrainResult.js
+++ b/frontend/src/services/normalizeTrainResult.js
@@ -27,6 +27,7 @@ export function normalizeTrainResult(res) {
   return {
     task: res?.task || "classification",
     metrics: res?.metrics || {},
+    per_class: res?.per_class || null,     // <- NOVO (tabela por classe)
     cv: res?.cv || {},
     cv_curve: res?.cv_curve || null,
     vip: extractVip(res),


### PR DESCRIPTION
## Summary
- add StratifiedKFold CV helper and expanded per-class metrics in /train
- expose latent sample labels and cumulative R²
- display per-class metrics and improve VIP/latent cards on frontend

## Testing
- `pytest`
- `npm test` *(fails: missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b87d176578832d825ba224685732b8