### PR TITLE
feat: sanitize JSON and stabilize CV metrics

### DIFF
--- a/frontend/src/components/nir/ConfusionMatrixCard.jsx
+++ b/frontend/src/components/nir/ConfusionMatrixCard.jsx
@@ -24,7 +24,7 @@ export default function ConfusionMatrixCard({ cm }) {
   return (
     <div className="card p-4" style={{minHeight: 420}}>
       <h3 className="card-title mb-3">Matriz de Confusão</h3>
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto" style={{maxHeight: 360, overflowY: "auto"}}>
         <table className="table table-sm">
           <thead>
             <tr>

--- a/frontend/src/components/nir/CvCurveCard.jsx
+++ b/frontend/src/components/nir/CvCurveCard.jsx
@@ -24,7 +24,7 @@ export default function CvCurveCard({ curve, task, recommended }) {
       <h3 className="card-title mb-3">
         Curva de Validação × Nº de Componentes
         {recommended ? (
-          <span className="badge ml-2">{recommended}</span>
+          <span className="badge ml-2">Sugerido: k = {recommended}</span>
         ) : null}
       </h3>
       <ResponsiveContainer width="100%" height={280}>

--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -46,7 +46,7 @@ export default function Step4Decision({ step2, result }) {
         <CvCurveCard
           curve={optimizeResult?.curve || data.cv_curve}
           task={data.task}
-          recommended={optimizeResult?.best_params?.n_components}
+          recommended={optimizeResult?.best_params?.n_components ?? data.recommended_n_components}
         />
         <LatentCard latent={data.latent} labels={data.latent?.sample_labels} />
       </div>

--- a/frontend/src/services/normalizeTrainResult.js
+++ b/frontend/src/services/normalizeTrainResult.js
@@ -30,6 +30,9 @@ export function normalizeTrainResult(res) {
     per_class: res?.per_class || null,     // <- NOVO (tabela por classe)
     cv: res?.cv || {},
     cv_curve: res?.cv_curve || null,
+    recommended_n_components: res?.recommended_n_components ?? null,
+    meta: res?.meta || null,
+    train_time_seconds: res?.train_time_seconds ?? null,
     vip: extractVip(res),
     cm: extractConfusion(res),
     wavelengths: res?.wavelengths || [],


### PR DESCRIPTION
## Summary
- add recursive JSON sanitization and finite-value helpers
- prevent NaN/Inf in CV curves and model metrics
- expose meta info and training time while returning sanitized responses
- show recommended components and unify card heights on front-end

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8922b309c832d94e8c0d7d30d85b3