### PR TITLE
Expose cross-validation metrics and optimize training UI

### DIFF
--- a/frontend/src/components/nir/CvCurveCard.jsx
+++ b/frontend/src/components/nir/CvCurveCard.jsx
@@ -20,11 +20,11 @@ export default function CvCurveCard({ curve, task, recommended }) {
   }
 
   return (
-    <div className="card p-4">
+    <div id="cv-curve" className="card p-4">
       <h3 className="card-title mb-3">
         Curva de Validação × Nº de Componentes
         {recommended ? (
-          <span className="badge ml-2">Sugerido: k = {recommended}</span>
+          <span className="ml-2 text-xs px-2 py-1 rounded bg-emerald-50 text-emerald-700 border border-emerald-200">Sugerido: k = {recommended}</span>
         ) : null}
       </h3>
       <ResponsiveContainer width="100%" height={280}>
@@ -36,10 +36,12 @@ export default function CvCurveCard({ curve, task, recommended }) {
           <Legend />
           {task === "classification" ? (
             <>
-              <Line type="monotone" dataKey="balanced_accuracy" stroke="#10b981" dot={false} strokeWidth={2} isAnimationActive={false} name="Balanced Acc." />
-              <Line type="monotone" dataKey="accuracy" stroke="#3b82f6" dot={false} strokeWidth={2} isAnimationActive={false} name="Accuracy" />
-              <Line type="monotone" dataKey="f1_macro" stroke="#f59e0b" dot={false} strokeWidth={2} isAnimationActive={false} name="F1 macro" />
-              <Line type="monotone" dataKey="auc_macro" stroke="#8b5cf6" dot={false} strokeWidth={2} isAnimationActive={false} name="AUC (macro)" />
+              <Line type="monotone" dataKey="balanced_accuracy" stroke="#10b981" strokeWidth={2} dot={false} isAnimationActive={false} name="Balanced Acc." />
+              <Line type="monotone" dataKey="accuracy"            stroke="#3b82f6"  strokeWidth={2} dot={false} isAnimationActive={false} name="Accuracy" />
+              <Line type="monotone" dataKey="f1_macro"            stroke="#f59e0b"  strokeWidth={2} dot={false} isAnimationActive={false} name="F1 macro" />
+              {data.some(d => d.auc_macro != null) && (
+                <Line type="monotone" dataKey="auc_macro" stroke="#8b5cf6" strokeWidth={2} dot={false} isAnimationActive={false} name="AUC (macro)" />
+              )}
             </>
           ) : (
             <>

--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { postOptimize } from "../../services/api";
+import { postOptimize, postTrain } from "../../services/api";
 import { getDatasetId } from "../../api/http";
 import VipTopCard from "./VipTopCard";
 import ConfusionMatrixCard from "./ConfusionMatrixCard";
@@ -8,67 +8,121 @@ import LatentCard from "./LatentCard";
 import PerClassMetricsCard from "./PerClassMetricsCard";
 import { normalizeTrainResult } from "../../services/normalizeTrainResult";
 
-export default function Step4Decision({ step2, result }) {
-  const [optimizeResult, setOptimizeResult] = useState(null);
-  const [busy, setBusy] = useState(false);
-  const data = useMemo(() => normalizeTrainResult(result?.data || result || {}), [result]);
+export default function Step4Decision({ step2, result, dataId }) {
+  const [trainRes, setTrainRes] = useState(result?.data || result || {});
+  const params = result?.params || {};
+  const [optLoading, setOptLoading] = useState(false);
+  const [bestInfo, setBestInfo] = useState(null);
+
+  const data = useMemo(() => normalizeTrainResult(trainRes), [trainRes]);
+
+  const metricsTrain = data.metrics || {};
+  const metricsValid = data.cv_metrics || data.metrics_valid || {};
+
+  function MetricsCard({ title, metrics }) {
+    const entries = Object.entries(metrics || {});
+    if (!entries.length) return (
+      <div className="card dashed h-64 flex items-center justify-center"><p>Sem dados.</p></div>
+    );
+    return (
+      <div className="card p-4" style={{ minHeight: 420 }}>
+        <h3 className="card-title mb-3">{title}</h3>
+        <div className="overflow-x-auto" style={{ maxHeight: 360, overflowY: "auto" }}>
+          <table className="table table-sm">
+            <tbody>
+              {entries.map(([k, v]) => (
+                <tr key={k}>
+                  <th>{k}</th>
+                  <td>{Number.isFinite(v) ? Number(v).toFixed(4) : String(v)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
 
   async function handleOptimize() {
-    if (!getDatasetId()) {
+    const ds = dataId || getDatasetId();
+    if (!ds) {
       alert("Dataset não encontrado — volte ao passo 1 e faça o upload.");
       return;
     }
-    setBusy(true);
+    setOptLoading(true);
     try {
-      const res = await postOptimize({
-        mode: step2?.classification ? "classification" : "regression",
+      const opt = await postOptimize({
+        dataset_id: ds,
         target_name: step2.target,
-        threshold: step2.threshold,
+        mode: step2.classification ? "classification" : "regression",
         validation_method: step2.validation_method,
         n_splits: step2.n_splits,
+        threshold: step2.threshold,
         k_min: 1,
-        k_max: step2.n_components_max,
+        k_max: step2.n_components_max || null,
       });
-      setOptimizeResult(res);
+
+      const bestK = opt?.best_params?.n_components;
+      if (bestK) {
+        const trained = await postTrain({
+          dataset_id: ds,
+          target_name: step2.target,
+          mode: step2.classification ? "classification" : "regression",
+          validation_method: step2.validation_method,
+          n_splits: step2.n_splits,
+          threshold: step2.threshold,
+          n_components: bestK,
+          preprocess: params.preprocess_steps?.map(p => p.method) || [],
+          spectral_ranges: params.ranges || null,
+        });
+        setTrainRes(trained);
+        setBestInfo({ k: bestK, score: opt?.best_score });
+        document.getElementById('cv-curve')?.scrollIntoView({ behavior: 'smooth' });
+      } else {
+        alert('Não foi possível sugerir k.');
+      }
+    } catch (e) {
+      console.error(e);
+      alert('Falha ao otimizar.');
     } finally {
-      setBusy(false);
+      setOptLoading(false);
     }
   }
 
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <MetricsCard title="Treino" metrics={metricsTrain} />
+        <MetricsCard title="Validação" metrics={metricsValid} />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <VipTopCard vip={data.vip} top={30} />
         <ConfusionMatrixCard cm={data.cm} />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <CvCurveCard
-          curve={optimizeResult?.curve || data.cv_curve}
-          task={data.task}
-          recommended={optimizeResult?.best_params?.n_components ?? data.recommended_n_components}
-        />
+        <CvCurveCard curve={data.cv_curve} task={data.task} recommended={data.recommended_n_components} />
         <LatentCard latent={data.latent} labels={data.latent?.sample_labels} />
       </div>
 
       <PerClassMetricsCard perClass={data.per_class} />
 
-      {!optimizeResult && (
-        <button
-          onClick={handleOptimize}
-          className="bg-blue-600 hover:bg-blue-700 text-white py-3 px-5 rounded-lg shadow-sm flex items-center disabled:opacity-50"
-          disabled={busy}
-        >
-          {busy ? <i className="fas fa-spinner fa-spin mr-2"></i> : <i className="fas fa-cogs mr-2"></i>}
-          Otimizar Modelo
-        </button>
-      )}
+      <button
+        onClick={handleOptimize}
+        className="bg-blue-600 hover:bg-blue-700 text-white py-3 px-5 rounded-lg shadow-sm flex items-center disabled:opacity-50"
+        disabled={optLoading}
+      >
+        {optLoading ? <i className="fas fa-spinner fa-spin mr-2"></i> : <i className="fas fa-cogs mr-2"></i>}
+        Otimizar Modelo
+      </button>
 
-      {optimizeResult && (
+      {bestInfo && (
         <div className="mt-4 text-sm text-gray-700">
-          Melhor n_components: {optimizeResult.best_params?.n_components} (score: {optimizeResult.best_score?.toFixed?.(3) ?? optimizeResult.best_score})
+          Modelo otimizado: k = {bestInfo.k} (score: {bestInfo.score?.toFixed?.(3) ?? bestInfo.score})
         </div>
       )}
     </div>
   );
 }
+

--- a/frontend/src/services/normalizeTrainResult.js
+++ b/frontend/src/services/normalizeTrainResult.js
@@ -29,6 +29,7 @@ export function normalizeTrainResult(res) {
     metrics: res?.metrics || {},
     per_class: res?.per_class || null,     // <- NOVO (tabela por classe)
     cv: res?.cv || {},
+    cv_metrics: res?.cv_metrics || null,
     cv_curve: res?.cv_curve || null,
     recommended_n_components: res?.recommended_n_components ?? null,
     meta: res?.meta || null,


### PR DESCRIPTION
## Summary
- add `_finite` and `_compute_cv_metrics` helpers to calculate CV metrics and attach them to training results
- enhance CV curve generation and frontend curve display with numeric-safe metrics and suggested `k`
- rework optimization flow to retrain with best `k` and show validation metrics on Step 4

## Testing
- `pytest`
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89996bdd0832dae93a5e773eefaaa