### PR TITLE
Handle empty CV curves and show diagnostics

### DIFF
--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -102,7 +102,7 @@ export default function Step4Decision({ step2, result, dataId }) {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <CvCurveCard curve={data.cv_curve} task={data.task} suggestedK={data.recommended_n_components} />
+        <CvCurveCard curve={data.cv_curve} task={data.task} />
         <LatentCard latent={data.latent} labels={data.latent?.sample_labels} />
       </div>
 


### PR DESCRIPTION
## Summary
- compute display CV curves and attach best k only when metric values are finite
- expose recommended k inside `cv_curve` and surface diagnostics for empty curves
- render CV curve card that filters NaNs and shows reason when no points

## Testing
- `pytest tests/`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9d5a15878832d808dd234ef7e18ce