### PR TITLE
fix: resilient preprocessing and clearer frontend errors

### DIFF
--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -82,8 +82,13 @@ export default function Step4Decision({ step2, result, dataId }) {
         alert('Não foi possível sugerir k.');
       }
     } catch (e) {
-      const detail = e?.response?.data?.detail || e?.data?.detail || e?.message || "Falha ao otimizar.";
-      const msg = typeof detail === "string" ? detail : (detail.message || JSON.stringify(detail));
+      const raw = e?.response?.data?.detail ?? e?.data?.detail ?? e?.message ?? e;
+      const msg =
+        typeof raw === "string"
+          ? raw
+          : raw?.message
+          ? `${raw.message}\n${JSON.stringify(raw, null, 2)}`
+          : JSON.stringify(raw, null, 2);
       alert(msg);
     } finally {
       setOptLoading(false);


### PR DESCRIPTION
## Summary
- make preprocessing robust to failures, logging them and continuing
- display backend optimization errors instead of `[object Object]`

## Testing
- `python -m py_compile backend/main.py`
- `pytest`
- `npm test --prefix frontend` *(fails: Missing script: "test")*
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb35a428832d90ce3a45d06827e8