### PR TITLE
Add navigation callbacks to NIR workflow steps

### DIFF
--- a/frontend/src/NirPage.jsx
+++ b/frontend/src/NirPage.jsx
@@ -85,7 +85,10 @@ export default function NirPage() {
             step2={step2}
             result={result}
             dataId={dataId}
-            onBack={() => setStep(3)}
+            onBack={(currentData, currentParams) => {
+              setResult({ data: currentData, params: currentParams });
+              setStep(3);
+            }}
             onContinue={(finalData, finalParams) => {
               setResult({ data: finalData, params: finalParams });
               setStep(5);
@@ -96,6 +99,9 @@ export default function NirPage() {
         {step === 5 && result && (
           <Step5Result
             result={result}
+            onBack={() => {
+              setStep(4);
+            }}
             onNew={() => resetAll()}
           />
         )}

--- a/frontend/src/components/nir/Step5Result.jsx
+++ b/frontend/src/components/nir/Step5Result.jsx
@@ -284,7 +284,7 @@ export default function Step5Result({ result, onBack, onNew }) {
 
       {/* AÇÕES */}
       <div className="flex gap-2 justify-end">
-        <button className="bg-gray-200 px-3 py-2 rounded" onClick={onBack}>
+        <button className="bg-gray-200 px-3 py-2 rounded" onClick={() => onBack?.()}>
           Voltar
         </button>
         <button


### PR DESCRIPTION
## Summary
- allow Step4Decision to expose explicit Back/Continue actions that return the latest training result and params, including optimization updates
- wire NirPage navigation so Step4Decision and Step5Result propagate state correctly when moving between steps
- guard the Step5Result back button to call the handler safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd3a8c1018832d9ac32da7b9ea2dbf