### PR TITLE
Add diagnostics report and Step 5 visualizations

### DIFF
--- a/frontend/src/components/nir/LatentCard.jsx
+++ b/frontend/src/components/nir/LatentCard.jsx
@@ -2,12 +2,14 @@ import React, { useMemo } from "react";
 import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 
 export default function LatentCard({ latent, labels }) {
-  const scores = latent?.scores || []; // [n, up to 3]
-  const data = useMemo(() => scores.map((row, i) => ({
+  const scoreMatrix = useMemo(() => (
+    Array.isArray(latent?.scores) ? latent.scores : []
+  ), [latent?.scores]);
+  const data = useMemo(() => scoreMatrix.map((row, i) => ({
     lv1: row[0] ?? 0, lv2: row[1] ?? 0, label: labels?.[i] ?? ""
-  })), [scores, labels]);
+  })), [scoreMatrix, labels]);
 
-  if (!scores.length) {
+  if (!scoreMatrix.length) {
     return <div className="card dashed h-64 flex items-center justify-center"><p>Sem variáveis latentes.</p></div>;
   }
 

--- a/frontend/src/components/nir/Step3Preprocess.jsx
+++ b/frontend/src/components/nir/Step3Preprocess.jsx
@@ -127,7 +127,10 @@ export default function Step3Preprocess({ meta, step2, onBack, onAnalyzed }) {
       yaxis: { range: [ymin - pad, ymax + pad] },
     };
 
-    Plotly.react(chartRef.current, traces, layout, { responsive: true, displayModeBar: false });
+    const node = chartRef.current;
+    if (!node) return () => {};
+
+    Plotly.react(node, traces, layout, { responsive: true, displayModeBar: false });
 
     const onSelected = (ev) => {
       if (ev?.range?.x) {
@@ -138,16 +141,14 @@ export default function Step3Preprocess({ meta, step2, onBack, onAnalyzed }) {
         setLambdaMax(bR);
         setRanges([[Math.min(aR, bR), Math.max(aR, bR)]]);
       }
-      Plotly.relayout(chartRef.current, { dragmode: "select" });
+      Plotly.relayout(node, { dragmode: "select" });
     };
 
-    chartRef.current.on("plotly_selected", onSelected);
+    node.on("plotly_selected", onSelected);
 
     return () => {
-      if (chartRef.current) {
-        chartRef.current.removeAllListeners?.("plotly_selected");
-        try { Plotly.purge(chartRef.current); } catch { /* ignore */ }
-      }
+      node?.removeAllListeners?.("plotly_selected");
+      try { Plotly.purge(node); } catch { /* ignore */ }
     };
   }, [wavelengths, series, meanLine, showMean, ranges]);
 

--- a/frontend/src/components/nir/Step5Result.jsx
+++ b/frontend/src/components/nir/Step5Result.jsx
@@ -1,83 +1,108 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import Plotly from "plotly.js-dist-min";
 import { postReport, downloadReport } from "../../services/api";
+import { normalizeTrainResult } from "../../services/normalizeTrainResult";
+
+function MetricsTable({ title, metrics }) {
+  const entries = Object.entries(metrics || {}).filter(([, v]) => v !== null && v !== undefined);
+  return (
+    <div className="card p-4 space-y-3">
+      <h3 className="card-title">{title}</h3>
+      {entries.length ? (
+        <table className="table table-sm">
+          <tbody>
+            {entries.map(([k, v]) => (
+              <tr key={k}>
+                <th className="font-medium text-gray-600">{k}</th>
+                <td>{Number.isFinite(v) ? Number(v).toFixed(4) : String(v)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="text-sm text-gray-500">Sem dados disponíveis.</p>
+      )}
+    </div>
+  );
+}
+
+function PerClassTable({ perClass }) {
+  if (!Array.isArray(perClass) || !perClass.length) {
+    return null;
+  }
+  return (
+    <div className="card p-4">
+      <h3 className="card-title mb-3">Desempenho por Classe</h3>
+      <div className="overflow-x-auto">
+        <table className="table table-sm">
+          <thead>
+            <tr>
+              <th>Classe</th>
+              <th>Precisão</th>
+              <th>Recall</th>
+              <th>F1</th>
+              <th>Suporte</th>
+            </tr>
+          </thead>
+          <tbody>
+            {perClass.map((row, idx) => (
+              <tr key={`${row.label}-${idx}`}>
+                <td>{row.label}</td>
+                <td>{Number(row.precision).toFixed(3)}</td>
+                <td>{Number(row.recall).toFixed(3)}</td>
+                <td>{Number(row.f1).toFixed(3)}</td>
+                <td>{row.support}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
 
 export default function Step5Result({ result, onBack, onNew }) {
-  const data = result?.data || {};
-  const params = result?.params || {};
+  const rawData = useMemo(() => result?.data || result || {}, [result]);
+  const data = useMemo(() => normalizeTrainResult(rawData), [rawData]);
 
   const {
-    metrics = {},
-    analysis_type = "PLS-R",
-    y_real = [],
-    y_pred = [],
-    vip = [],
-    features = [],
-    scores = [],
-    class_mapping = null,
-    top_vips = [],
-    range_used = "",
-    interpretacao_vips = null,
-    resumo_interpretativo = "",
-    validation_used = null,
-    n_splits_effective = null,
-    best = null,
-    per_class = null,
-    curves = null,
+    task,
+    metrics,
+    cv_metrics: cvMetrics,
+    residuals,
+    influence,
+    distributions,
+    predictions,
+    per_class: perClass,
   } = data;
 
-  const isClass = analysis_type === "PLS-DA";
-
-  // refs p/ Plotly
-  const vipRef = useRef(null);
-  const scatterRef = useRef(null);
-  const cmRef = useRef(null);
+  const residualRef = useRef(null);
+  const stdResidualRef = useRef(null);
+  const leverageRef = useRef(null);
+  const histogramRef = useRef(null);
 
   const [downloading, setDownloading] = useState(false);
 
-  // labels de classes (quando houver)
-  const classLabels = useMemo(() => {
-    if (class_mapping && typeof class_mapping === "object") {
-      return Object.keys(class_mapping)
-        .sort((a, b) => Number(a) - Number(b))
-        .map((k) => class_mapping[k]);
-    }
-    // fallback: únicas em y_real
-    return [...new Set(y_real || [])];
-  }, [class_mapping, y_real]);
+  const residualOutliers = residuals?.outliers?.length ?? 0;
+  const highLeverage = influence?.high_leverage?.length ?? 0;
+  const hotellingOutliers = influence?.hotelling_outliers?.length ?? 0;
 
-  // MÉTRICAS (tabela simples)
-  function MetricsTable({ m }) {
-    const rows = [];
-    for (const [k, v] of Object.entries(m || {})) {
-      if (typeof v === "object") continue; // pula blocos (ex: ConfusionMatrix)
-      rows.push([k, v]);
-    }
-    return (
-      <table className="min-w-full text-sm">
-        <thead>
-          <tr>
-            <th className="px-4 py-2 border-b text-left">Métrica</th>
-            <th className="px-4 py-2 border-b text-left">Valor</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map(([k, v]) => (
-            <tr key={k}>
-              <td className="px-4 py-2 border-b font-semibold">{k}</td>
-              <td className="px-4 py-2 border-b">
-                {Number.isFinite(v) ? Number(v).toFixed(4) : String(v)}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    );
-  }
+  const leverageThreshold = influence?.leverage_threshold ?? null;
+  const stdThreshold = residuals?.std_threshold ?? null;
+  const hotellingThreshold = influence?.hotelling_t2_threshold ?? null;
 
-  const renderPlot = (ref, traces, layout, config = { responsive: true }) => {
+  const sampleIndex = useMemo(() => {
+    const base = residuals?.sample_index ?? predictions?.sample_index ?? [];
+    return Array.isArray(base) ? base : [];
+  }, [residuals?.sample_index, predictions?.sample_index]);
+
+  const renderPlot = (ref, traces, layout) => {
     if (!ref?.current) return () => {};
-    Plotly.newPlot(ref.current, traces, layout, config);
+    if (!Array.isArray(traces) || !traces.length) {
+      ref.current.innerHTML = "<div class='text-sm text-gray-500'>Sem dados para exibir.</div>";
+      return () => {};
+    }
+    Plotly.newPlot(ref.current, traces, layout, { responsive: true, displaylogo: false });
     return () => {
       try {
         Plotly.purge(ref.current);
@@ -87,139 +112,282 @@ export default function Step5Result({ result, onBack, onNew }) {
     };
   };
 
-  // VIP chart
   useEffect(() => {
-    const trace = {
-      x: features,
-      y: vip,
-      type: "bar",
-    };
-    return renderPlot(vipRef, [trace], {
-      title: "VIP Scores",
-      margin: { t: 40, r: 20, l: 40, b: 80 },
-    });
-  }, [features, vip]);
+    if (!residuals?.predicted?.length || !residuals?.raw?.length) {
+      if (residualRef.current) {
+        residualRef.current.innerHTML = "<div class='text-sm text-gray-500'>Sem dados de resíduos.</div>";
+      }
+      return () => {};
+    }
 
-  // Scatter / Scores / Real vs Pred
-  useEffect(() => {
-    if (!scatterRef.current) return;
+    const preds = residuals.predicted;
+    const res = residuals.raw;
+    const labels = residuals.y_true || [];
+    const predsLabel = residuals.y_pred || [];
+    const idxMap = new Map(sampleIndex.map((id, pos) => [id, pos]));
+    const outlierSet = new Set(residuals.outliers || []);
 
-    if (isClass && scores?.length) {
-      const xs = scores.map((s) => s[0]);
-      const ys = scores.map((s) => s[1] ?? 0);
-      const trace = {
+    const buildTrace = (ids, name, color) => {
+      const xs = ids.map((id) => preds[idxMap.get(id)]);
+      const ys = ids.map((id) => res[idxMap.get(id)]);
+      const text = ids.map((id) => {
+        const pos = idxMap.get(id);
+        const lbl = labels[pos] ?? "";
+        const predLbl = predsLabel[pos] ?? "";
+        return `Amostra ${id}<br>Real: ${lbl}<br>Previsto: ${predLbl}`;
+      });
+      return {
         x: xs,
         y: ys,
         mode: "markers",
         type: "scatter",
-        marker: { color: y_real },
-        text: y_real,
+        name,
+        text,
+        hovertemplate: "%{text}<br>Previsto: %{x:.3f}<br>Resíduo: %{y:.3f}<extra></extra>",
+        marker: { size: 8, color },
       };
-      return renderPlot(
-        scatterRef,
-        [trace],
-        {
-          title: "Scores PLS",
-          xaxis: { title: "Comp 1" },
-          yaxis: { title: "Comp 2" },
-        }
-      );
-    } else if (!isClass && y_real?.length && y_pred?.length) {
-      const trace = {
-        x: y_real,
-        y: y_pred,
-        mode: "markers",
-        type: "scatter",
-      };
-      return renderPlot(
-        scatterRef,
-        [trace],
-        {
-          title: "y_real vs y_previsto",
-          xaxis: { title: "y_real" },
-          yaxis: { title: "y_previsto" },
-        }
-      );
-    } else {
-      try {
-        Plotly.purge(scatterRef.current);
-      } catch {
-        /* ignore */
-      }
-      scatterRef.current.innerHTML = "<div class='text-sm text-gray-500'>Sem dados para o gráfico.</div>";
-    }
-  }, [isClass, scores, y_real, y_pred]);
+    };
 
-  // Confusion Matrix (se houver)
+    const outlierIds = sampleIndex.filter((id) => outlierSet.has(id));
+    const inlierIds = sampleIndex.filter((id) => !outlierSet.has(id));
+
+    const traces = [];
+    if (inlierIds.length) traces.push(buildTrace(inlierIds, "Amostras", "#1f77b4"));
+    if (outlierIds.length) traces.push(buildTrace(outlierIds, "Outliers", "#d62728"));
+    traces.push({
+      x: [Math.min(...preds), Math.max(...preds)],
+      y: [0, 0],
+      mode: "lines",
+      name: "Resíduo = 0",
+      line: { color: "#888", dash: "dash" },
+      hoverinfo: "skip",
+    });
+
+    return renderPlot(residualRef, traces, {
+      title: "Resíduos vs. Previsto",
+      xaxis: { title: task === "classification" ? "Probabilidade prevista" : "Valor previsto" },
+      yaxis: { title: "Resíduo" },
+      margin: { t: 40, r: 20, l: 50, b: 50 },
+    });
+  }, [residuals, sampleIndex, task]);
+
   useEffect(() => {
-    if (!cmRef.current) return;
-
-    const cm = metrics?.ConfusionMatrix;
-    if (isClass && cm && cm.length) {
-      const heat = {
-        z: cm,
-        x: classLabels,
-        y: classLabels,
-        type: "heatmap",
-        colorscale: "YlGnBu",
-        text: cm.map((r) => r.map(String)),
-        texttemplate: "%{text}",
-        textfont: { color: "black" },
-      };
-      const layout = {
-        title: "Matriz de Confusão",
-        xaxis: { title: "Predito" },
-        yaxis: { title: "Real" },
-        margin: { t: 40, r: 20, l: 40, b: 40 },
-      };
-      return renderPlot(cmRef, [heat], layout);
-    } else {
-      try {
-        Plotly.purge(cmRef.current);
-      } catch {
-        /* ignore */
+    if (!residuals?.standardized?.length) {
+      if (stdResidualRef.current) {
+        stdResidualRef.current.innerHTML = "<div class='text-sm text-gray-500'>Sem dados padronizados.</div>";
       }
-      cmRef.current.innerHTML = "";
+      return () => {};
     }
-  }, [isClass, metrics, classLabels]);
+
+    const stdValues = residuals.standardized;
+    const idx = sampleIndex;
+    if (!idx.length) {
+      if (stdResidualRef.current) {
+        stdResidualRef.current.innerHTML = "<div class='text-sm text-gray-500'>Sem índice de amostras.</div>";
+      }
+      return () => {};
+    }
+    const outlierSet = new Set(residuals.outliers || []);
+    const traceBase = {
+      x: idx,
+      y: stdValues,
+      mode: "markers",
+      type: "scatter",
+      name: "Resíduo padronizado",
+      marker: { color: "#2ca02c", size: 8 },
+      hovertemplate: "Amostra %{x}<br>Valor: %{y:.2f}<extra></extra>",
+    };
+    const traceOut = {
+      x: idx.filter((id) => outlierSet.has(id)),
+      y: idx.filter((id) => outlierSet.has(id)).map((id) => stdValues[idx.indexOf(id)]),
+      mode: "markers",
+      type: "scatter",
+      name: "Outliers",
+      marker: { color: "#d62728", size: 10 },
+      hovertemplate: "Amostra %{x}<br>Valor: %{y:.2f}<extra></extra>",
+    };
+
+    const threshold = Number(stdThreshold) || 3;
+
+    const traces = [traceBase];
+    if (traceOut.x.length) traces.push(traceOut);
+    traces.push({
+      x: [Math.min(...idx), Math.max(...idx)],
+      y: [threshold, threshold],
+      mode: "lines",
+      name: `+${threshold.toFixed(1)}σ`,
+      line: { color: "#ff7f0e", dash: "dot" },
+      hoverinfo: "skip",
+    });
+    traces.push({
+      x: [Math.min(...idx), Math.max(...idx)],
+      y: [-threshold, -threshold],
+      mode: "lines",
+      name: `-${threshold.toFixed(1)}σ`,
+      line: { color: "#ff7f0e", dash: "dot" },
+      hoverinfo: "skip",
+    });
+
+    return renderPlot(stdResidualRef, traces, {
+      title: "Resíduos Padronizados",
+      xaxis: { title: "Índice da amostra" },
+      yaxis: { title: "Resíduo padronizado" },
+      margin: { t: 40, r: 20, l: 50, b: 50 },
+    });
+  }, [residuals, sampleIndex, stdThreshold]);
+
+  useEffect(() => {
+    if (!influence?.leverage?.length) {
+      if (leverageRef.current) {
+        leverageRef.current.innerHTML = "<div class='text-sm text-gray-500'>Sem dados de leverage.</div>";
+      }
+      return () => {};
+    }
+
+    const lev = influence.leverage;
+    const idx = sampleIndex.length === lev.length ? sampleIndex : lev.map((_, i) => i);
+    if (!idx.length) {
+      if (leverageRef.current) {
+        leverageRef.current.innerHTML = "<div class='text-sm text-gray-500'>Sem índice de amostras.</div>";
+      }
+      return () => {};
+    }
+    const outSet = new Set(influence.high_leverage || []);
+    const traceBase = {
+      x: idx,
+      y: lev,
+      mode: "markers",
+      type: "scatter",
+      name: "Leverage",
+      marker: { color: "#17becf", size: 8 },
+      hovertemplate: "Amostra %{x}<br>Leverage: %{y:.3f}<extra></extra>",
+    };
+    const traceOut = {
+      x: idx.filter((id) => outSet.has(id)),
+      y: idx.filter((id) => outSet.has(id)).map((id) => lev[idx.indexOf(id)]),
+      mode: "markers",
+      type: "scatter",
+      name: "Leverage alto",
+      marker: { color: "#d62728", size: 10 },
+      hovertemplate: "Amostra %{x}<br>Leverage: %{y:.3f}<extra></extra>",
+    };
+
+    const threshold = Number(leverageThreshold) || 0;
+
+    const traces = [traceBase];
+    if (traceOut.x.length) traces.push(traceOut);
+    if (threshold > 0) {
+      traces.push({
+        x: [Math.min(...idx), Math.max(...idx)],
+        y: [threshold, threshold],
+        mode: "lines",
+        name: `Limite (${threshold.toFixed(3)})`,
+        line: { color: "#ff7f0e", dash: "dash" },
+        hoverinfo: "skip",
+      });
+    }
+
+    return renderPlot(leverageRef, traces, {
+      title: "Leverage (Hotelling T²)",
+      xaxis: { title: "Índice da amostra" },
+      yaxis: { title: "Leverage" },
+      margin: { t: 40, r: 20, l: 50, b: 50 },
+    });
+  }, [influence, sampleIndex, leverageThreshold]);
+
+  useEffect(() => {
+    const prob = distributions?.probabilities;
+    const predHist = distributions?.predicted;
+
+    if (task === "classification" && prob && Object.keys(prob).length) {
+      const traces = Object.entries(prob)
+        .map(([label, hist]) => {
+          const edges = hist?.bin_edges || [];
+          const counts = hist?.counts || [];
+          if (!edges.length || !counts.length) return null;
+          const centers = edges.slice(0, -1).map((e, i) => (e + edges[i + 1]) / 2);
+          return {
+            type: "bar",
+            name: label,
+            x: centers,
+            y: counts,
+            opacity: 0.75,
+          };
+        })
+        .filter(Boolean);
+      return renderPlot(histogramRef, traces, {
+        barmode: "stack",
+        title: "Distribuição das Probabilidades Previstas",
+        xaxis: { title: "Probabilidade", range: [0, 1] },
+        yaxis: { title: "Frequência" },
+        margin: { t: 40, r: 20, l: 50, b: 50 },
+      });
+    }
+
+    if (task === "regression" && predHist?.bin_edges?.length) {
+      const edges = predHist.bin_edges;
+      const counts = predHist.counts || [];
+      const centers = edges.slice(0, -1).map((e, i) => (e + edges[i + 1]) / 2);
+      const trace = {
+        type: "bar",
+        x: centers,
+        y: counts,
+        marker: { color: "#1f77b4" },
+      };
+      return renderPlot(histogramRef, [trace], {
+        title: "Distribuição das Previsões",
+        xaxis: { title: "Valor previsto" },
+        yaxis: { title: "Frequência" },
+        margin: { t: 40, r: 20, l: 50, b: 50 },
+      });
+    }
+
+    if (histogramRef.current) {
+      histogramRef.current.innerHTML = "<div class='text-sm text-gray-500'>Sem histogramas disponíveis.</div>";
+    }
+    return () => {};
+  }, [distributions, task]);
 
   async function handleDownloadPDF() {
     try {
       setDownloading(true);
-      const payload = {
-        metrics,
-        params: {
-          ...params,
-          analysis_type,
-          class_mapping,
-        },
-        y_real,
-        y_pred,
-        vip,
-        top_vips,
-        scores,
-        interpretacao_vips,
-        resumo_interpretativo,
-        validation_used,
-        n_splits_effective,
-        range_used,
-        best,
-        per_class,
-        curves,
+      const metricPayload = {
+        ...Object.fromEntries(Object.entries(metrics || {}).map(([k, v]) => [`Treino - ${k}`, v])),
+        ...Object.fromEntries(Object.entries(cvMetrics || {}).map(([k, v]) => [`Validação - ${k}`, v])),
       };
-      const { path } = await postReport(payload);
-      const blob = await downloadReport(path);
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = "relatorio.pdf";
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    } catch (e) {
-      console.error(e);
-      alert("Falha ao gerar PDF.");
+      const curvesRaw = Array.isArray(rawData?.curves)
+        ? rawData.curves
+        : rawData?.curves
+        ? [rawData.curves]
+        : [];
+      if (!curvesRaw.length && data?.cv_curve?.points) {
+        curvesRaw.push(data.cv_curve);
+      }
+      const payload = {
+        metrics: metricPayload,
+        params: result?.params || {},
+        validation_used: rawData?.validation_used || data?.cv?.validation?.method,
+        n_splits_effective: rawData?.n_splits_effective || data?.cv?.validation?.splits,
+        range_used: rawData?.range_used,
+        best: rawData?.best,
+        per_class: perClass,
+        curves: curvesRaw,
+      };
+      const resp = await postReport(payload);
+      if (resp?.path) {
+        const blob = await downloadReport(resp.path);
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "relatorio_nir.pdf";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+      }
+    } catch (err) {
+      const msg = err?.message || "Falha ao gerar relatório.";
+      alert(msg);
     } finally {
       setDownloading(false);
     }
@@ -227,89 +395,104 @@ export default function Step5Result({ result, onBack, onNew }) {
 
   return (
     <div className="space-y-6">
-      {/* Info de validação / resumo */}
-      <p className="text-sm text-gray-700">
-        {params?.validation_display ? `Validação: ${params.validation_display}` : ""}
-      </p>
-
-      {/* MÉTRICAS */}
-      <div className="bg-white rounded-lg shadow p-4">
-        <h3 className="text-lg font-semibold mb-2">Métricas</h3>
-        <MetricsTable m={metrics} />
-      </div>
-
-      {/* GRÁFICOS */}
-      <div className="grid grid-cols-1 gap-6">
-        <div className="bg-white rounded-lg shadow p-4">
-          <h3 className="text-lg font-semibold mb-2">{isClass ? "Scores PLS" : "Dispersão"}</h3>
-          <div ref={scatterRef} className="w-full h-80" />
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-[#2e5339]">Resultado Final</h2>
+          <p className="text-sm text-gray-600">
+            {task === "classification"
+              ? "Modelo PLS-DA com diagnóstico completo de resíduos e influência."
+              : "Modelo PLS-R com análise de resíduos e previsão."}
+          </p>
         </div>
+        <div className="flex gap-2">
+          <button
+            onClick={handleDownloadPDF}
+            className="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-lg shadow-sm disabled:opacity-60"
+            disabled={downloading}
+          >
+            {downloading ? <i className="fas fa-spinner fa-spin mr-2" /> : <i className="fas fa-file-download mr-2" />}
+            Baixar relatório PDF
+          </button>
+          <button
+            onClick={onNew}
+            className="bg-emerald-700 hover:bg-emerald-800 text-white py-2 px-4 rounded-lg"
+          >
+            Novo projeto
+          </button>
+        </div>
+      </header>
 
-        {isClass && (
-          <div className="bg-white rounded-lg shadow p-4">
-            <h3 className="text-lg font-semibold mb-2">Matriz de Confusão</h3>
-            <div ref={cmRef} className="w-full h-80" />
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[
+          {
+            title: "Resíduos extremos",
+            value: residualOutliers,
+            description: stdThreshold
+              ? `|resíduo padronizado| > ${Number(stdThreshold).toFixed(1)}`
+              : "|resíduo padronizado| > 3",
+          },
+          {
+            title: "Leverage elevado",
+            value: highLeverage,
+            description: leverageThreshold
+              ? `Leverage > ${Number(leverageThreshold).toFixed(3)}`
+              : "Acima do limite recomendado",
+          },
+          {
+            title: "Hotelling T²",
+            value: hotellingOutliers,
+            description: hotellingThreshold
+              ? `Acima de ${Number(hotellingThreshold).toFixed(2)}`
+              : "Acima do percentil 95%",
+          },
+        ].map((card) => (
+          <div
+            key={card.title}
+            className={`card p-4 border ${card.value ? "border-red-300 bg-red-50" : "border-green-200 bg-green-50"}`}
+          >
+            <h3 className="text-lg font-semibold text-gray-700">{card.title}</h3>
+            <p className="text-3xl font-bold text-gray-900">{card.value}</p>
+            <p className="text-sm text-gray-600">{card.description}</p>
           </div>
-        )}
+        ))}
+      </div>
 
-        <div className="bg-white rounded-lg shadow p-4">
-          <h3 className="text-lg font-semibold mb-2">VIP Scores</h3>
-          <div ref={vipRef} className="w-full h-80" />
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <MetricsTable title="Métricas de Treino" metrics={metrics} />
+        <MetricsTable title="Métricas de Validação" metrics={cvMetrics} />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="card p-4">
+          <div ref={residualRef} style={{ minHeight: 320 }} />
+        </div>
+        <div className="card p-4">
+          <div ref={stdResidualRef} style={{ minHeight: 320 }} />
         </div>
       </div>
 
-      {/* INTERPRETAÇÃO */}
-      <div className="bg-white rounded-lg shadow p-4">
-        <h3 className="text-lg font-semibold mb-2">Interpretação do Modelo</h3>
-        <p className="text-sm text-gray-600 mb-2">
-          {range_used ? `Faixa utilizada: ${range_used}` : ""}
-        </p>
-        <div className="overflow-auto">
-          <table className="min-w-full text-sm">
-            <thead>
-              <tr>
-                <th className="px-4 py-2 border-b text-left">λ (nm)</th>
-                <th className="px-4 py-2 border-b text-left">VIP</th>
-                <th className="px-4 py-2 border-b text-left">Associação</th>
-              </tr>
-            </thead>
-            <tbody>
-              {(top_vips || []).map((row, idx) => (
-                <tr key={idx}>
-                  <td className="px-4 py-2 border-b">{row.wavelength}</td>
-                  <td className="px-4 py-2 border-b">
-                    {Number.isFinite(row.vip) ? row.vip.toFixed(2) : row.vip}
-                  </td>
-                  <td className="px-4 py-2 border-b">{row.label || ""}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="card p-4">
+          <div ref={leverageRef} style={{ minHeight: 320 }} />
         </div>
-
-        {resumo_interpretativo && (
-          <p className="text-sm text-gray-700 mt-3">{resumo_interpretativo}</p>
-        )}
+        <div className="card p-4">
+          <div ref={histogramRef} style={{ minHeight: 320 }} />
+        </div>
       </div>
 
-      {/* AÇÕES */}
-      <div className="flex gap-2 justify-end">
-        <button className="bg-gray-200 px-3 py-2 rounded" onClick={() => onBack?.()}>
+      <PerClassTable perClass={perClass} />
+
+      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-between">
+        <button onClick={onBack} className="bg-gray-200 hover:bg-gray-300 text-gray-800 py-2 px-4 rounded-lg">
           Voltar
         </button>
-        <button
-          className="bg-[#2e5339] hover:bg-[#305e6b] text-white px-4 py-2 rounded"
-          onClick={handleDownloadPDF}
-          disabled={downloading}
-        >
-          {downloading ? "Gerando..." : "Baixar PDF"}
-        </button>
-        <button
-          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
-          onClick={onNew}
-        >
-          Nova análise
-        </button>
+        <div className="text-sm text-gray-600">
+          {predictions?.class_labels?.length
+            ? `Classes: ${predictions.class_labels.join(", ")}`
+            : task === "regression"
+            ? "Modelo de regressão"
+            : ""}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/services/normalizeTrainResult.js
+++ b/frontend/src/services/normalizeTrainResult.js
@@ -39,5 +39,9 @@ export function normalizeTrainResult(res) {
     wavelengths: res?.wavelengths || [],
     latent: res?.latent || null,
     oof: res?.oof || null,
+    residuals: res?.residuals || null,
+    influence: res?.influence || null,
+    distributions: res?.distributions || null,
+    predictions: res?.predictions || null,
   };
 }


### PR DESCRIPTION
## Summary
- implement residual, leverage, and prediction-distribution diagnostics inside `build_full_report_for_ui`
- expose the new backend diagnostics through the train result normalizer for the frontend
- redesign the Step 5 results page with residual/leverage Plotly charts, summary cards, and related hook fixes

## Testing
- npm run lint
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68cd52eb22cc832d9db831da3fd59371