### PR TITLE
Fix Savitzky-Golay factorial and add derivative test

### DIFF
--- a/backend/ml/preprocessing.py
+++ b/backend/ml/preprocessing.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 
 
@@ -29,7 +31,7 @@ def savgol_1d(X: np.ndarray, window: int = 11, polyorder: int = 2, deriv: int = 
     V = np.hstack([x ** p for p in range(polyorder + 1)])
     Vinv = np.linalg.pinv(V)
     e = np.zeros((polyorder + 1, 1))
-    e[deriv, 0] = np.math.factorial(deriv)
+    e[deriv, 0] = math.factorial(deriv)
     coef = (Vinv.T @ e).ravel()
     Xpad = np.pad(X, ((0, 0), (half, half)), mode="reflect")
     out = np.empty_like(X, dtype=float)

--- a/backend/tests/test_preprocessing.py
+++ b/backend/tests/test_preprocessing.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ml.preprocessing import sg_first_derivative, sg_second_derivative
+
+
+def test_savgol_derivatives_do_not_raise():
+    X = np.tile(np.linspace(0.0, 1.0, 21, dtype=float), (3, 1))
+
+    first = sg_first_derivative(X)
+    second = sg_second_derivative(X)
+
+    assert first.shape == X.shape
+    assert second.shape == X.shape


### PR DESCRIPTION
## Summary
- import the standard library math module in `ml.preprocessing` and rely on it for factorial
- add a regression test ensuring the Savitzky-Golay derivative helpers execute without errors

## Testing
- pytest backend/tests/test_preprocessing.py

------
https://chatgpt.com/codex/tasks/task_e_68cd89823c20832d82ef3cee5cb62891