### PR TITLE
feat: support spectral range object on training

### DIFF
--- a/frontend/src/components/nir/Step3Preprocess.jsx
+++ b/frontend/src/components/nir/Step3Preprocess.jsx
@@ -184,6 +184,15 @@ export default function Step3Preprocess({ meta, step2, onBack, onAnalyzed }) {
       ).map((i) => i.value);
 
       const rangesStr = ranges.map(([a, b]) => `${a}-${b}`).join(",");
+      const firstValidRange = ranges.find(([a, b]) =>
+        Number.isFinite(a) && Number.isFinite(b) && a !== b
+      );
+      const spectralRange = firstValidRange
+        ? {
+            min: Math.min(firstValidRange[0], firstValidRange[1]),
+            max: Math.max(firstValidRange[0], firstValidRange[1]),
+          }
+        : null;
 
       const dsId = getDatasetId();
       if (!dsId) throw new Error("Dataset não encontrado. Volte ao passo 1 e reenvie o arquivo.");
@@ -196,7 +205,7 @@ export default function Step3Preprocess({ meta, step2, onBack, onAnalyzed }) {
         n_bootstrap: step2.n_bootstrap ?? 0,
         validation_method: step2.validation_method,
         validation_params: step2.validation_params || {},
-        spectral_ranges: rangesStr,
+        spectral_range: spectralRange,
         preprocess: checked,
       };
 
@@ -210,6 +219,7 @@ export default function Step3Preprocess({ meta, step2, onBack, onAnalyzed }) {
       const fullParams = {
         ...step2,
         ranges: rangesStr,
+        spectral_range: spectralRange,
         preprocess_steps: preprocessSteps,
         range_used: data.range_used,
       };


### PR DESCRIPTION
## Summary
- convert preprocess step 3 to forward the first selected window as a `spectral_range` object while keeping legacy text for display
- normalise spectral ranges inside the API client and Step 4, carrying the new `spectral_range` and derived preprocess grid through optimisation and retraining calls
- build preprocess grids from the currently selected preprocessing methods so optimisation sticks to the chosen pipelines

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68cd941b83b0832d8c069f64512d1bf2