### PR TITLE
Ensure n_splits forwarded with training requests

### DIFF
--- a/frontend/src/components/nir/Step4Decision.jsx
+++ b/frontend/src/components/nir/Step4Decision.jsx
@@ -307,6 +307,7 @@ export default function Step4Decision({ step2, result, dataId, onBack, onContinu
           mode: combinedParams.classification ? "classification" : "regression",
           validation_method: validationMethod,
           validation_params: validationParams,
+          n_splits: nSplits ?? undefined,
           n_bootstrap: nBootstrap,
           threshold,
           n_components: bestK,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -229,6 +229,19 @@ export async function postTrain(payload) {
     preprocess_grid: payload.preprocess_grid,
     sg: payload.sg ?? (Array.isArray(payload.sg_params) && payload.sg_params.length ? payload.sg_params[0] : undefined),
   };
+  if (body.n_splits === undefined) {
+    const nSplitsCandidate =
+      payload?.n_splits ??
+      payload?.validation_params?.n_splits ??
+      payload?.validation_params?.nSplits ??
+      payload?.validation_params?.folds ??
+      payload?.validation_params?.k ??
+      payload?.validation_params?.nFolds;
+    const parsedNSplits = Number(nSplitsCandidate);
+    if (Number.isFinite(parsedNSplits) && parsedNSplits > 0) {
+      body.n_splits = parsedNSplits;
+    }
+  }
   return postJSON(`${API_BASE}/train`, body);
 }
 


### PR DESCRIPTION
## Summary
- extract the K-Fold split count from step 2 parameters in the preprocess step and forward it to training
- reuse the previously computed split count when re-training after optimisation
- fallback to validation parameters inside the postTrain helper to keep n_splits in sync

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2a5d95304832d8819e816799d1759