### PR TITLE
Improve optimization feedback and report exports

### DIFF
--- a/backend/core/templates/report_template.html
+++ b/backend/core/templates/report_template.html
@@ -26,20 +26,20 @@
 <h2>Melhor modelo</h2>
 <table border="1" cellspacing="0" cellpadding="3">
 <tr><th>Pré-processo</th><th>VL</th><th>Métrica</th><th>Valor</th></tr>
-{% if best.val_metrics %}
-{% for k, v in best.val_metrics.items() %}
-<tr><td>{{ best.preprocess }}</td><td>{{ best.n_components }}</td><td>{{ k }}</td><td>{{ v }}</td></tr>
+{% if best_metrics_rows %}
+{% for metric in best_metrics_rows %}
+<tr><td>{{ best.preprocess }}</td><td>{{ best.n_components }}</td><td>{{ metric.name }}</td><td>{{ metric.value }}</td></tr>
 {% endfor %}
 {% endif %}
 </table>
 {% endif %}
 
-{% if per_class %}
+{% if per_class_rows %}
 <h3>Métricas por classe</h3>
 <table border="1" cellspacing="0" cellpadding="3">
 <tr><th>Classe</th><th>Precisão</th><th>Revocação</th><th>F1</th><th>Suporte</th></tr>
-{% for cls, met in per_class.items() %}
-<tr><td>{{ cls }}</td><td>{{ met.precision }}</td><td>{{ met.recall }}</td><td>{{ met.f1 }}</td><td>{{ met.support }}</td></tr>
+{% for row in per_class_rows %}
+<tr><td>{{ row.label }}</td><td>{{ row.precision }}</td><td>{{ row.recall }}</td><td>{{ row.f1 }}</td><td>{{ row.support }}</td></tr>
 {% endfor %}
 </table>
 {% endif %}

--- a/frontend/src/components/nir/LatentCard.jsx
+++ b/frontend/src/components/nir/LatentCard.jsx
@@ -14,8 +14,41 @@ export default function LatentCard({ latent, labels }) {
   }
 
   // Paleta simples por classe
-  const uniq = Array.from(new Set(data.map(d => d.label)));
-  const colors = ["#2563eb","#16a34a","#f59e0b","#ef4444","#7c3aed","#0ea5e9","#84cc16","#d946ef","#fb7185","#22c55e"];
+  const uniq = useMemo(() => Array.from(new Set(data.map((d) => d.label))), [data]);
+  const colorMap = useMemo(() => {
+    const basePalette = [
+      "#2563eb",
+      "#16a34a",
+      "#f97316",
+      "#db2777",
+      "#14b8a6",
+      "#a855f7",
+      "#facc15",
+      "#0ea5e9",
+      "#ef4444",
+      "#22c55e",
+      "#6366f1",
+      "#fb7185",
+      "#2dd4bf",
+      "#f59e0b",
+      "#10b981",
+      "#e11d48",
+      "#8b5cf6",
+      "#06b6d4",
+      "#f973ab",
+      "#84cc16",
+    ];
+    const map = new Map();
+    uniq.forEach((label, idx) => {
+      let color = basePalette[idx];
+      if (!color) {
+        const hue = (idx * 137.508) % 360;
+        color = `hsl(${hue.toFixed(1)}, 68%, 55%)`;
+      }
+      map.set(label, color);
+    });
+    return map;
+  }, [uniq]);
 
   return (
     <div className="card p-4">
@@ -28,9 +61,20 @@ export default function LatentCard({ latent, labels }) {
               <XAxis type="number" dataKey="lv1" name="LV1" />
               <YAxis type="number" dataKey="lv2" name="LV2" />
               <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-              <Legend />
-              {uniq.map((c, idx) => (
-                <Scatter key={c} name={c} data={data.filter(d => d.label === c)} fill={colors[idx % colors.length]} />
+              <Legend
+                verticalAlign="top"
+                align="center"
+                iconType="circle"
+                wrapperStyle={{ paddingBottom: 12, maxWidth: "100%" }}
+              />
+              {uniq.map((c) => (
+                <Scatter
+                  key={c}
+                  name={c}
+                  data={data.filter((d) => d.label === c)}
+                  fill={colorMap.get(c) || "#4b5563"}
+                  stroke={colorMap.get(c) || "#4b5563"}
+                />
               ))}
             </ScatterChart>
           </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- add polling of /optimize/status to Step 4 with progress bar, ETA and run summary
- refresh latent scatter palette to ensure unique colors for each class
- harden PDF report generation when per-class metrics and best-model metrics arrive as lists

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68bf3b601c84832d974fc0c366e8e648