### PR TITLE
Reduce optimization polling overhead

### DIFF
--- a/frontend/src/components/nir/LatentCard.jsx
+++ b/frontend/src/components/nir/LatentCard.jsx
@@ -9,11 +9,6 @@ export default function LatentCard({ latent, labels }) {
     lv1: row[0] ?? 0, lv2: row[1] ?? 0, label: labels?.[i] ?? ""
   })), [scoreMatrix, labels]);
 
-  if (!scoreMatrix.length) {
-    return <div className="card dashed h-64 flex items-center justify-center"><p>Sem variáveis latentes.</p></div>;
-  }
-
-  // Paleta simples por classe
   const uniq = useMemo(() => Array.from(new Set(data.map((d) => d.label))), [data]);
   const colorMap = useMemo(() => {
     const basePalette = [
@@ -49,6 +44,10 @@ export default function LatentCard({ latent, labels }) {
     });
     return map;
   }, [uniq]);
+
+  if (!scoreMatrix.length) {
+    return <div className="card dashed h-64 flex items-center justify-center"><p>Sem variáveis latentes.</p></div>;
+  }
 
   return (
     <div className="card p-4">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -69,8 +69,8 @@ export async function postOptimize(payload = {}) {
   return postJSON(`${API_BASE}/optimize`, cleaned);
 }
 
-export async function getOptimizeStatus() {
-  const res = await fetch(`${API_BASE}/optimize/status`);
+export async function getOptimizeStatus({ signal } = {}) {
+  const res = await fetch(`${API_BASE}/optimize/status`, { signal });
   if (!res.ok) {
     let msg;
     try { const j = await res.json(); msg = j.detail || JSON.stringify(j); }


### PR DESCRIPTION
## Summary
- add abortable fetch option for the optimization status endpoint
- replace fixed 1s interval polling with adaptive timeout logic to cut redundant requests while keeping progress responsive
- tidy latent score card hooks so they are evaluated consistently for lint compliance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4376a2584832daec87c41d7d977fe