### PR TITLE
Fix residual outlier detection for column vector targets

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2714,7 +2714,7 @@ def build_full_report_for_ui(X, y, task, n_components, classifier, threshold_map
     """Constrói blocos extras para o front a partir do melhor modelo."""
 
     X = np.asarray(X, dtype=float)
-    y = np.asarray(y)
+    y = np.asarray(y).ravel()
     n_samples = X.shape[0]
     if n_samples == 0:
         return {}


### PR DESCRIPTION
## Summary
- ensure response vector is ravelled in build_full_report_for_ui so downstream residual calculations stay one-dimensional
- prevents residual standardization from broadcasting over 2D targets which incorrectly flagged every sample as an outlier

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d441a2c570832da0392b90a17f2268